### PR TITLE
Fix WebSocket example

### DIFF
--- a/examples/http3_client.py
+++ b/examples/http3_client.py
@@ -137,6 +137,7 @@ class HttpClient(QuicConnectionProtocol):
             (b":authority", authority.encode("utf8")),
             (b":path", path.encode("utf8")),
             (b":protocol", b"websocket"),
+            (b"sec-websocket-version", b"13"),
         ]
         if subprotocols:
             headers.append(


### PR DESCRIPTION
The connection request is missing a version header (this header is
required).