### PR TITLE
add peer_address public method

### DIFF
--- a/examples/http3_server.py
+++ b/examples/http3_server.py
@@ -257,8 +257,7 @@ class HttpServerProtocol(QuicConnectionProtocol):
                 path_bytes, query_string = raw_path, b""
             path = path_bytes.decode()
 
-            # FIXME: add a public API to retrieve peer address
-            client_addr = self._http._quic._network_paths[0].addr
+            client_addr = self._http.peer_address()
             client = (client_addr[0], client_addr[1])
 
             handler: Handler

--- a/src/aioquic/h0/connection.py
+++ b/src/aioquic/h0/connection.py
@@ -1,7 +1,7 @@
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 from aioquic.h3.events import DataReceived, H3Event, Headers, HeadersReceived
-from aioquic.quic.connection import QuicConnection
+from aioquic.quic.connection import NetworkAddress, QuicConnection
 from aioquic.quic.events import QuicEvent, StreamDataReceived
 
 H0_ALPN = ["hq-27", "hq-26", "hq-25"]
@@ -61,3 +61,9 @@ class H0Connection:
         else:
             data = b""
         self._quic.send_stream_data(stream_id, data, end_stream)
+
+    def peer_address(self) -> Optional[NetworkAddress]:
+        """
+        :return: Refer to QuicConnection.peer_address
+        """
+        return self._quic.peer_address()

--- a/src/aioquic/h3/connection.py
+++ b/src/aioquic/h3/connection.py
@@ -13,7 +13,11 @@ from aioquic.h3.events import (
     PushPromiseReceived,
 )
 from aioquic.h3.exceptions import NoAvailablePushIDError
-from aioquic.quic.connection import QuicConnection, stream_is_unidirectional
+from aioquic.quic.connection import (
+    NetworkAddress,
+    QuicConnection,
+    stream_is_unidirectional,
+)
 from aioquic.quic.events import QuicEvent, StreamDataReceived
 from aioquic.quic.logger import QuicLoggerTrace
 
@@ -359,6 +363,14 @@ class H3Connection:
         self._quic.send_stream_data(
             stream_id, encode_frame(FrameType.HEADERS, frame_data), end_stream
         )
+
+    def peer_address(self) -> Optional[NetworkAddress]:
+        """
+        :return: Refer to QuicConnection.peer_address
+        """
+        return self._quic.peer_address()
+
+    # Private methods
 
     def _create_uni_stream(self, stream_type: int) -> int:
         """

--- a/src/aioquic/quic/connection.py
+++ b/src/aioquic/quic/connection.py
@@ -969,6 +969,15 @@ class QuicConnection:
             stream = self._streams[stream_id]
         stream.write(data, end_stream=end_stream)
 
+    def peer_address(self) -> Optional[NetworkAddress]:
+        """
+        :return: NetworkAddress of the peer, or None if not connected.
+        """
+        if len(self._network_paths) > 0:
+            return self._network_paths[0].addr  # use the first network path
+        else:
+            return None
+
     # Private
 
     def _alpn_handler(self, alpn_protocol: str) -> None:

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1776,6 +1776,26 @@ class QuicConnectionTest(TestCase):
         )
         self.assertEqual(drop(client), 1)
 
+    def test_peer_address(self):
+        # verify the return value when connected
+        with client_and_server() as (client, server):
+            consume_events(client)
+
+            peer = server.peer_address()
+            self.assertEqual(peer, CLIENT_ADDR)
+
+            peer = client.peer_address()
+            self.assertEqual(peer, SERVER_ADDR)
+
+        # verify returning None when not connected
+        dummy_configuration = QuicConfiguration(
+            is_client=True, quic_logger=QuicLogger()
+        )
+        dummy_configuration.load_verify_locations(cafile=SERVER_CACERTFILE)
+        client = QuicConnection(configuration=dummy_configuration)
+        peer = client.peer_address()
+        self.assertIsNone(peer)
+
 
 class QuicNetworkPathTest(TestCase):
     def test_can_send(self):


### PR DESCRIPTION
This is to provide a public method `peer_address` for `QuicConnection`, `H0Connection`, `H3Connection` and use it in the `http3_server.py` example.
