### PR TITLE
Properly calculate Session Ticket's obfuscated age

### DIFF
--- a/src/aioquic/tls.py
+++ b/src/aioquic/tls.py
@@ -1161,7 +1161,7 @@ class SessionTicket:
 
     @property
     def obfuscated_age(self) -> int:
-        age = int((utcnow() - self.not_valid_before).total_seconds())
+        age = int((utcnow() - self.not_valid_before).total_seconds() * 1000)
         return (age + self.age_add) % (1 << 32)
 
 


### PR DESCRIPTION
Per https://tools.ietf.org/html/rfc8446#section-4.2.11.1:
> Note that the "ticket_lifetime" field in the NewSessionTicket message
   is in seconds but the "obfuscated_ticket_age" is in milliseconds.

This caused problems in interop with QUIC stacks, as the valid time of a ticket was suddenly off by a factor of 1000 (e.g., leading to a ticket only being usable for 10 seconds instead of a few hours/days). 

NOTE: I'm not sure I'm following the logic entirely, but it seems the server doesn't really check the lifetime of a ticket it previously issued either? _build_session_ticket() seems to just take the current timestamp + lifetime, meaning it's always valid? But I must be reading it wrong, at 10:45 PM :)