### PR TITLE
[tests] upgrade pip using "python -m pip"

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,7 +47,7 @@ jobs:
           echo "::set-env name=LINK::/LIBPATH:C:\Progra~1\OpenSSL-Win64\lib"
       - name: Run tests
         run: |
-          pip install -U pip setuptools wheel
+          python -m pip install -U pip setuptools wheel
           pip install coverage
           pip install .
           coverage run -m unittest discover -v


### PR DESCRIPTION
Otherwise we get the following error on Windows:

```
ERROR: Could not install packages due to an EnvironmentError: [WinError 5] Access is denied: 'C:\\Users\\runneradmin\\AppData\\Local\\Temp\\pip-uninstall-8qvpbo6s\\pip.exe'
Consider using the `--user` option or check the permissions.
```