### PR TITLE
[tls] send an empty legacy_session_id in ClientHello

### DIFF
--- a/src/aioquic/tls.py
+++ b/src/aioquic/tls.py
@@ -550,9 +550,9 @@ class OfferedPsks:
 @dataclass
 class ClientHello:
     random: bytes
-    session_id: bytes
+    legacy_session_id: bytes
     cipher_suites: List[int]
-    compression_methods: List[int]
+    legacy_compression_methods: List[int]
 
     # extensions
     alpn_protocols: Optional[List[str]] = None
@@ -572,13 +572,12 @@ def pull_client_hello(buf: Buffer) -> ClientHello:
     assert buf.pull_uint8() == HandshakeType.CLIENT_HELLO
     with pull_block(buf, 3):
         assert buf.pull_uint16() == TLS_VERSION_1_2
-        client_random = buf.pull_bytes(32)
 
         hello = ClientHello(
-            random=client_random,
-            session_id=pull_opaque(buf, 1),
+            random=buf.pull_bytes(32),
+            legacy_session_id=pull_opaque(buf, 1),
             cipher_suites=pull_list(buf, 2, buf.pull_uint16),
-            compression_methods=pull_list(buf, 1, buf.pull_uint8),
+            legacy_compression_methods=pull_list(buf, 1, buf.pull_uint8),
         )
 
         # extensions
@@ -632,9 +631,9 @@ def push_client_hello(buf: Buffer, hello: ClientHello) -> None:
     with push_block(buf, 3):
         buf.push_uint16(TLS_VERSION_1_2)
         buf.push_bytes(hello.random)
-        push_opaque(buf, 1, hello.session_id)
+        push_opaque(buf, 1, hello.legacy_session_id)
         push_list(buf, 2, buf.push_uint16, hello.cipher_suites)
-        push_list(buf, 1, buf.push_uint8, hello.compression_methods)
+        push_list(buf, 1, buf.push_uint8, hello.legacy_compression_methods)
 
         # extensions
         with push_block(buf, 2):
@@ -694,7 +693,7 @@ def push_client_hello(buf: Buffer, hello: ClientHello) -> None:
 @dataclass
 class ServerHello:
     random: bytes
-    session_id: bytes
+    legacy_session_id: bytes
     cipher_suite: int
     compression_method: int
 
@@ -709,11 +708,10 @@ def pull_server_hello(buf: Buffer) -> ServerHello:
     assert buf.pull_uint8() == HandshakeType.SERVER_HELLO
     with pull_block(buf, 3):
         assert buf.pull_uint16() == TLS_VERSION_1_2
-        server_random = buf.pull_bytes(32)
 
         hello = ServerHello(
-            random=server_random,
-            session_id=pull_opaque(buf, 1),
+            random=buf.pull_bytes(32),
+            legacy_session_id=pull_opaque(buf, 1),
             cipher_suite=buf.pull_uint16(),
             compression_method=buf.pull_uint8(),
         )
@@ -744,7 +742,7 @@ def push_server_hello(buf: Buffer, hello: ServerHello) -> None:
         buf.push_uint16(TLS_VERSION_1_2)
         buf.push_bytes(hello.random)
 
-        push_opaque(buf, 1, hello.session_id)
+        push_opaque(buf, 1, hello.legacy_session_id)
         buf.push_uint16(hello.cipher_suite)
         buf.push_uint8(hello.compression_method)
 
@@ -1216,7 +1214,7 @@ class Context:
             CipherSuite.AES_128_GCM_SHA256,
             CipherSuite.CHACHA20_POLY1305_SHA256,
         ]
-        self._compression_methods: List[int] = [CompressionMethod.NULL]
+        self._legacy_compression_methods: List[int] = [CompressionMethod.NULL]
         self._psk_key_exchange_modes: List[int] = [PskKeyExchangeMode.PSK_DHE_KE]
         self._signature_algorithms: List[int] = [
             SignatureAlgorithm.RSA_PSS_RSAE_SHA256,
@@ -1253,11 +1251,11 @@ class Context:
 
         if is_client:
             self.client_random = os.urandom(32)
-            self.session_id = os.urandom(32)
+            self.legacy_session_id = os.urandom(32)
             self.state = State.CLIENT_HANDSHAKE_START
         else:
             self.client_random = None
-            self.session_id = None
+            self.legacy_session_id = None
             self.state = State.SERVER_EXPECT_CLIENT_HELLO
 
     @property
@@ -1402,9 +1400,9 @@ class Context:
 
         hello = ClientHello(
             random=self.client_random,
-            session_id=self.session_id,
+            legacy_session_id=self.legacy_session_id,
             cipher_suites=[int(x) for x in self._cipher_suites],
-            compression_methods=self._compression_methods,
+            legacy_compression_methods=self._legacy_compression_methods,
             alpn_protocols=self._alpn_protocols,
             key_share=key_share,
             psk_key_exchange_modes=self._psk_key_exchange_modes
@@ -1473,7 +1471,7 @@ class Context:
             [peer_hello.cipher_suite],
             AlertHandshakeFailure("Unsupported cipher suite"),
         )
-        assert peer_hello.compression_method in self._compression_methods
+        assert peer_hello.compression_method in self._legacy_compression_methods
         assert peer_hello.supported_version in self._supported_versions
 
         # select key schedule
@@ -1665,8 +1663,8 @@ class Context:
             AlertHandshakeFailure("No supported cipher suite"),
         )
         compression_method = negotiate(
-            self._compression_methods,
-            peer_hello.compression_methods,
+            self._legacy_compression_methods,
+            peer_hello.legacy_compression_methods,
             AlertHandshakeFailure("No supported compression method"),
         )
         psk_key_exchange_mode = negotiate(
@@ -1695,7 +1693,7 @@ class Context:
 
         self.client_random = peer_hello.random
         self.server_random = os.urandom(32)
-        self.session_id = peer_hello.session_id
+        self.legacy_session_id = peer_hello.legacy_session_id
         self.received_extensions = peer_hello.other_extensions
 
         # select key schedule
@@ -1787,7 +1785,7 @@ class Context:
         # send hello
         hello = ServerHello(
             random=self.server_random,
-            session_id=self.session_id,
+            legacy_session_id=self.legacy_session_id,
             cipher_suite=cipher_suite,
             compression_method=compression_method,
             key_share=encode_public_key(public_key),

--- a/src/aioquic/tls.py
+++ b/src/aioquic/tls.py
@@ -1251,7 +1251,7 @@ class Context:
 
         if is_client:
             self.client_random = os.urandom(32)
-            self.legacy_session_id = os.urandom(32)
+            self.legacy_session_id = b""
             self.state = State.CLIENT_HANDSHAKE_START
         else:
             self.client_random = None

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -316,7 +316,7 @@ class QuicConnectionTest(TestCase):
         now = 1.1
         server.receive_datagram(items[0][0], CLIENT_ADDR, now=now)
         items = server.datagrams_to_send(now=now)
-        self.assertEqual(datagram_sizes(items), [1280, 1062])
+        self.assertEqual(datagram_sizes(items), [1280, 1030])
         self.assertEqual(server.get_timer(), 2.1)
         self.assertEqual(len(server._loss.spaces[0].sent_packets), 1)
         self.assertEqual(len(server._loss.spaces[1].sent_packets), 2)
@@ -377,7 +377,7 @@ class QuicConnectionTest(TestCase):
         now = 0.1
         server.receive_datagram(items[0][0], CLIENT_ADDR, now=now)
         items = server.datagrams_to_send(now=now)
-        self.assertEqual(datagram_sizes(items), [1280, 1062])
+        self.assertEqual(datagram_sizes(items), [1280, 1030])
         self.assertEqual(server.get_timer(), 1.1)
         self.assertEqual(len(server._loss.spaces[0].sent_packets), 1)
         self.assertEqual(len(server._loss.spaces[1].sent_packets), 2)
@@ -470,7 +470,7 @@ class QuicConnectionTest(TestCase):
         now = 0.1
         server.receive_datagram(items[0][0], CLIENT_ADDR, now=now)
         items = server.datagrams_to_send(now=now)
-        self.assertEqual(datagram_sizes(items), [1280, 1062])
+        self.assertEqual(datagram_sizes(items), [1280, 1030])
         self.assertEqual(server.get_timer(), 1.1)
         self.assertEqual(len(server._loss.spaces[0].sent_packets), 1)
         self.assertEqual(len(server._loss.spaces[1].sent_packets), 2)

--- a/tests/test_tls.py
+++ b/tests/test_tls.py
@@ -613,7 +613,7 @@ class TlsTest(TestCase):
             ),
         )
         self.assertEqual(
-            hello.session_id,
+            hello.legacy_session_id,
             binascii.unhexlify(
                 "9aee82a2d186c1cb32a329d9dcfe004a1a438ad0485a53c6bfcf55c132a23235"
             ),
@@ -626,7 +626,7 @@ class TlsTest(TestCase):
                 tls.CipherSuite.CHACHA20_POLY1305_SHA256,
             ],
         )
-        self.assertEqual(hello.compression_methods, [tls.CompressionMethod.NULL])
+        self.assertEqual(hello.legacy_compression_methods, [tls.CompressionMethod.NULL])
 
         # extensions
         self.assertEqual(hello.alpn_protocols, None)
@@ -688,7 +688,7 @@ class TlsTest(TestCase):
                 "ed575c6fbd599c4dfaabd003dca6e860ccdb0e1782c1af02e57bf27cb6479b76"
             ),
         )
-        self.assertEqual(hello.session_id, b"")
+        self.assertEqual(hello.legacy_session_id, b"")
         self.assertEqual(
             hello.cipher_suites,
             [
@@ -698,7 +698,7 @@ class TlsTest(TestCase):
                 tls.CipherSuite.EMPTY_RENEGOTIATION_INFO_SCSV,
             ],
         )
-        self.assertEqual(hello.compression_methods, [tls.CompressionMethod.NULL])
+        self.assertEqual(hello.legacy_compression_methods, [tls.CompressionMethod.NULL])
 
         # extensions
         self.assertEqual(hello.alpn_protocols, ["h3-19"])
@@ -802,7 +802,7 @@ class TlsTest(TestCase):
             ),
         )
         self.assertEqual(
-            hello.session_id,
+            hello.legacy_session_id,
             binascii.unhexlify(
                 "26b19bdd30dbf751015a3a16e13bd59002dfe420b799d2a5cd5e11b8fa7bcb66"
             ),
@@ -815,7 +815,7 @@ class TlsTest(TestCase):
                 tls.CipherSuite.CHACHA20_POLY1305_SHA256,
             ],
         )
-        self.assertEqual(hello.compression_methods, [tls.CompressionMethod.NULL])
+        self.assertEqual(hello.legacy_compression_methods, [tls.CompressionMethod.NULL])
 
         # extensions
         self.assertEqual(hello.alpn_protocols, None)
@@ -876,7 +876,7 @@ class TlsTest(TestCase):
             random=binascii.unhexlify(
                 "18b2b23bf3e44b5d52ccfe7aecbc5ff14eadc3d349fabf804d71f165ae76e7d5"
             ),
-            session_id=binascii.unhexlify(
+            legacy_session_id=binascii.unhexlify(
                 "9aee82a2d186c1cb32a329d9dcfe004a1a438ad0485a53c6bfcf55c132a23235"
             ),
             cipher_suites=[
@@ -884,7 +884,7 @@ class TlsTest(TestCase):
                 tls.CipherSuite.AES_128_GCM_SHA256,
                 tls.CipherSuite.CHACHA20_POLY1305_SHA256,
             ],
-            compression_methods=[tls.CompressionMethod.NULL],
+            legacy_compression_methods=[tls.CompressionMethod.NULL],
             key_share=[
                 (
                     tls.Group.SECP256R1,
@@ -933,7 +933,7 @@ class TlsTest(TestCase):
             ),
         )
         self.assertEqual(
-            hello.session_id,
+            hello.legacy_session_id,
             binascii.unhexlify(
                 "9aee82a2d186c1cb32a329d9dcfe004a1a438ad0485a53c6bfcf55c132a23235"
             ),
@@ -966,7 +966,7 @@ class TlsTest(TestCase):
             ),
         )
         self.assertEqual(
-            hello.session_id,
+            hello.legacy_session_id,
             binascii.unhexlify(
                 "9483e7e895d0f4cec17086b0849601c0632662cd764e828f2f892f4c4b7771b0"
             ),
@@ -1003,7 +1003,7 @@ class TlsTest(TestCase):
                 random=binascii.unhexlify(
                     "ada85271d19680c615ea7336519e3fdf6f1e26f3b1075ee1de96ffa8884e8280"
                 ),
-                session_id=binascii.unhexlify(
+                legacy_session_id=binascii.unhexlify(
                     "9aee82a2d186c1cb32a329d9dcfe004a1a438ad0485a53c6bfcf55c132a23235"
                 ),
                 cipher_suite=tls.CipherSuite.AES_256_GCM_SHA384,
@@ -1031,7 +1031,7 @@ class TlsTest(TestCase):
             random=binascii.unhexlify(
                 "ada85271d19680c615ea7336519e3fdf6f1e26f3b1075ee1de96ffa8884e8280"
             ),
-            session_id=binascii.unhexlify(
+            legacy_session_id=binascii.unhexlify(
                 "9aee82a2d186c1cb32a329d9dcfe004a1a438ad0485a53c6bfcf55c132a23235"
             ),
             cipher_suite=tls.CipherSuite.AES_256_GCM_SHA384,

--- a/tests/test_tls.py
+++ b/tests/test_tls.py
@@ -314,7 +314,7 @@ class ContextTest(TestCase):
         client.handle_message(b"", client_buf)
         self.assertEqual(client.state, State.CLIENT_EXPECT_SERVER_HELLO)
         server_input = merge_buffers(client_buf)
-        self.assertGreaterEqual(len(server_input), 213)
+        self.assertGreaterEqual(len(server_input), 181)
         self.assertLessEqual(len(server_input), 358)
         reset_buffers(client_buf)
 
@@ -507,7 +507,7 @@ class ContextTest(TestCase):
             server.handle_message(server_input, server_buf)
             self.assertEqual(server.state, State.SERVER_EXPECT_FINISHED)
             client_input = merge_buffers(server_buf)
-            self.assertEqual(len(client_input), 307)
+            self.assertEqual(len(client_input), 275)
             reset_buffers(server_buf)
 
             # handle server hello, encrypted extensions, certificate, certificate verify, finished
@@ -587,7 +587,7 @@ class ContextTest(TestCase):
             buf.seek(buf.tell() - 1)
             buf.push_uint8(1)
             client_input = merge_buffers(server_buf)
-            self.assertEqual(len(client_input), 307)
+            self.assertEqual(len(client_input), 275)
             reset_buffers(server_buf)
 
             # handle server hello and bomb


### PR DESCRIPTION
QUIC draft 28 explicitly forbids the use of TLS 1.3 "compatibility mode", so our legacy_session_id should always be empty.