### PR TITLE
Do not use "stateless retry" terminology

### DIFF
--- a/examples/doq_server.py
+++ b/examples/doq_server.py
@@ -100,17 +100,13 @@ if __name__ == "__main__":
         help="load the TLS certificate from the specified file",
     )
     parser.add_argument(
-        "-r",
         "--resolver",
         type=str,
         default="8.8.8.8",
         help="Upstream Classic DNS resolver to use",
     )
     parser.add_argument(
-        "-s",
-        "--stateless-retry",
-        action="store_true",
-        help="send a stateless retry for new connections",
+        "--retry", action="store_true", help="send a retry for new connections",
     )
     parser.add_argument(
         "-q",
@@ -156,7 +152,7 @@ if __name__ == "__main__":
             create_protocol=DnsServerProtocol,
             session_ticket_fetcher=ticket_store.pop,
             session_ticket_handler=ticket_store.add,
-            stateless_retry=args.stateless_retry,
+            retry=args.retry,
         )
     )
     try:

--- a/examples/http3_server.py
+++ b/examples/http3_server.py
@@ -400,10 +400,7 @@ if __name__ == "__main__":
         help="log QUIC events to QLOG files in the specified directory",
     )
     parser.add_argument(
-        "-r",
-        "--stateless-retry",
-        action="store_true",
-        help="send a stateless retry for new connections",
+        "--retry", action="store_true", help="send a retry for new connections",
     )
     parser.add_argument(
         "-v", "--verbose", action="store_true", help="increase logging verbosity"
@@ -456,7 +453,7 @@ if __name__ == "__main__":
             create_protocol=HttpServerProtocol,
             session_ticket_fetcher=ticket_store.pop,
             session_ticket_handler=ticket_store.add,
-            stateless_retry=args.stateless_retry,
+            retry=args.retry,
         )
     )
     try:

--- a/examples/interop.py
+++ b/examples/interop.py
@@ -151,7 +151,7 @@ async def test_handshake_and_close(server: Server, configuration: QuicConfigurat
     server.result |= Result.C
 
 
-async def test_stateless_retry(server: Server, configuration: QuicConfiguration):
+async def test_retry(server: Server, configuration: QuicConfiguration):
     # skip test if there is not retry port
     if server.retry_port is None:
         return

--- a/src/aioquic/quic/connection.py
+++ b/src/aioquic/quic/connection.py
@@ -303,12 +303,12 @@ class QuicConnection:
         self._remote_max_stream_data_uni = 0
         self._remote_max_streams_bidi = 0
         self._remote_max_streams_uni = 0
+        self._retry_count = 0
         self._retry_source_connection_id = retry_source_connection_id
         self._spaces: Dict[tls.Epoch, QuicPacketSpace] = {}
         self._spin_bit = False
         self._spin_highest_pn = 0
         self._state = QuicConnectionState.FIRSTFLIGHT
-        self._stateless_retry_count = 0
         self._streams: Dict[int, QuicStream] = {}
         self._streams_blocked_bidi: List[QuicStream] = []
         self._streams_blocked_uni: List[QuicStream] = []
@@ -747,7 +747,7 @@ class QuicConnection:
                 return
 
             if self._is_client and header.packet_type == PACKET_TYPE_RETRY:
-                # calculate stateless retry integrity tag
+                # calculate retry integrity tag
                 integrity_tag = get_retry_integrity_tag(
                     buf.data_slice(start_off, buf.tell() - RETRY_INTEGRITY_TAG_SIZE),
                     self._peer_cid.cid,
@@ -757,7 +757,7 @@ class QuicConnection:
                 if (
                     header.destination_cid == self.host_cid
                     and header.integrity_tag == integrity_tag
-                    and not self._stateless_retry_count
+                    and not self._retry_count
                 ):
                     if self._quic_logger is not None:
                         self._quic_logger.log_event(
@@ -775,9 +775,9 @@ class QuicConnection:
 
                     self._peer_cid.cid = header.source_cid
                     self._peer_token = header.token
+                    self._retry_count += 1
                     self._retry_source_connection_id = header.source_cid
-                    self._stateless_retry_count += 1
-                    self._logger.info("Performing stateless retry")
+                    self._logger.info("Performing retry")
                     self._connect(now=now)
                 return
 

--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -240,14 +240,12 @@ class HighLevelTest(TestCase):
         )
         self.assertEqual(response, b"gnip")
 
-    def test_connect_and_serve_with_stateless_retry(self):
+    def test_connect_and_serve_with_retry(self):
         run(self.run_server())
         response = run(self.run_client())
         self.assertEqual(response, b"gnip")
 
-    def test_connect_and_serve_with_stateless_retry_bad_original_destination_connection_id(
-        self,
-    ):
+    def test_connect_and_serve_with_retry_bad_original_destination_connection_id(self):
         """
         If the server's transport parameters do not have the correct
         original_destination_connection_id the connection must fail.
@@ -258,13 +256,11 @@ class HighLevelTest(TestCase):
             protocol._quic._original_destination_connection_id = None
             return protocol
 
-        run(self.run_server(create_protocol=create_protocol, stateless_retry=True))
+        run(self.run_server(create_protocol=create_protocol, retry=True))
         with self.assertRaises(ConnectionError):
             run(self.run_client())
 
-    def test_connect_and_serve_with_stateless_retry_bad_retry_source_connection_id(
-        self,
-    ):
+    def test_connect_and_serve_with_retry_bad_retry_source_connection_id(self):
         """
         If the server's transport parameters do not have the correct
         retry_source_connection_id the connection must fail.
@@ -275,15 +271,15 @@ class HighLevelTest(TestCase):
             protocol._quic._retry_source_connection_id = None
             return protocol
 
-        run(self.run_server(create_protocol=create_protocol, stateless_retry=True))
+        run(self.run_server(create_protocol=create_protocol, retry=True))
         with self.assertRaises(ConnectionError):
             run(self.run_client())
 
     @patch("aioquic.quic.retry.QuicRetryTokenHandler.validate_token")
-    def test_connect_and_serve_with_stateless_retry_bad_token(self, mock_validate):
+    def test_connect_and_serve_with_retry_bad_token(self, mock_validate):
         mock_validate.side_effect = ValueError("Decryption failed.")
 
-        run(self.run_server(stateless_retry=True))
+        run(self.run_server(retry=True))
         with self.assertRaises(ConnectionError):
             run(
                 self.run_client(


### PR DESCRIPTION
The specs now refer to "retry" without the "stateless" qualifier.