### PR TITLE
[build] don't build wheels for pypy for now

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -90,7 +90,7 @@ jobs:
           CIBW_BEFORE_BUILD_WINDOWS: python scripts\fetch-vendor C:\cibw\vendor
           CIBW_ENVIRONMENT: AIOQUIC_SKIP_TESTS=ipv6,loss CFLAGS=-I/tmp/vendor/include LDFLAGS=-L/tmp/vendor/lib
           CIBW_ENVIRONMENT_WINDOWS: AIOQUIC_SKIP_TESTS=ipv6,loss CL="/IC:\cibw\vendor\include" LINK="/LIBPATH:C:\cibw\vendor\lib"
-          CIBW_SKIP: cp27-* cp33-* cp34-* cp35-* pp27-*
+          CIBW_SKIP: cp27-* cp33-* cp34-* cp35-* pp27-* pp3*-macosx_x86_64
           CIBW_TEST_COMMAND: python -m unittest discover -t {project} -s {project}/tests
         run: |
           pip install cibuildwheel==1.4.2


### PR DESCRIPTION
Support for pypy seems to be broken on OSX with the current cibuildwheel, but we cannot upgrade cibuildwheel as it breaks Windows.