### PR TITLE
[connection] refactor sending close event

### DIFF
--- a/src/aioquic/quic/connection.py
+++ b/src/aioquic/quic/connection.py
@@ -498,11 +498,14 @@ class QuicConnection:
             version=self._version,
         )
         if self._close_pending:
-            for epoch, packet_type in (
-                (tls.Epoch.ONE_RTT, PACKET_TYPE_ONE_RTT),
-                (tls.Epoch.HANDSHAKE, PACKET_TYPE_HANDSHAKE),
-                (tls.Epoch.INITIAL, PACKET_TYPE_INITIAL),
-            ):
+            epoch_packet_types = []
+            if not self._handshake_confirmed:
+                epoch_packet_types += [
+                    (tls.Epoch.INITIAL, PACKET_TYPE_INITIAL),
+                    (tls.Epoch.HANDSHAKE, PACKET_TYPE_HANDSHAKE),
+                ]
+            epoch_packet_types.append((tls.Epoch.ONE_RTT, PACKET_TYPE_ONE_RTT))
+            for epoch, packet_type in epoch_packet_types:
                 crypto = self._cryptos[epoch]
                 if crypto.send.is_valid():
                     builder.start_packet(packet_type, crypto)


### PR DESCRIPTION
Only use 1-RTT to send close event if the handshake has been confirmed.