### PR TITLE
[connection] arm idle timeout on first datagram for servers

### DIFF
--- a/src/aioquic/quic/connection.py
+++ b/src/aioquic/quic/connection.py
@@ -682,12 +682,17 @@ class QuicConnection:
         if self._state in END_STATES:
             return
 
+        # log datagram
         if self._quic_logger is not None:
             self._quic_logger.log_event(
                 category="transport",
                 event="datagrams_received",
                 data={"byte_length": len(data), "count": 1},
             )
+
+        # for servers, arm the idle timeout on the first datagram
+        if self._close_at is None:
+            self._close_at = now + self._configuration.idle_timeout
 
         buf = Buffer(data=data)
         while not buf.eof():

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -987,6 +987,23 @@ class QuicConnectionTest(TestCase):
         )
         self.assertEqual(drop(client), 0)
 
+    def test_receive_datagram_retry_wrong_integrity_tag(self):
+        client = create_standalone_client(self)
+
+        client.receive_datagram(
+            encode_quic_retry(
+                version=client._version,
+                source_cid=binascii.unhexlify("85abb547bf28be97"),
+                destination_cid=client.host_cid,
+                original_destination_cid=client._peer_cid.cid,
+                retry_token=bytes(16),
+            )[0:-16]
+            + bytes(16),
+            SERVER_ADDR,
+            now=time.time(),
+        )
+        self.assertEqual(drop(client), 0)
+
     def test_handle_ack_frame_ecn(self):
         client = create_standalone_client(self)
 


### PR DESCRIPTION
When a server connection receives its first diagram, arm the idle
timeout timer. Otherwise if the first datagram is not processed correctly
the timer will never be started.