### PR TITLE
Only override configuration.server_name if it's not already set

### DIFF
--- a/src/aioquic/asyncio/client.py
+++ b/src/aioquic/asyncio/client.py
@@ -72,7 +72,7 @@ async def connect(
     # prepare QUIC connection
     if configuration is None:
         configuration = QuicConfiguration(is_client=True)
-    if server_name is not None:
+    if configuration.server_name is None:
         configuration.server_name = server_name
     connection = QuicConnection(
         configuration=configuration, session_ticket_handler=session_ticket_handler


### PR DESCRIPTION
This PR preserves the value of `configuration.server_name` if it has already been set. 

We use an SNI that's different from the hostname, so we need to set it manually. As the code is now, we're unable to do so because `server_name` is always overwritten with the hostname. This patch fixes that issue.