### PR TITLE
[connection] update path challenge according to the draft [JF & CC]

### DIFF
--- a/src/aioquic/quic/connection.py
+++ b/src/aioquic/quic/connection.py
@@ -177,12 +177,14 @@ class QuicConnectionState(Enum):
     DRAINING = 3
     TERMINATED = 4
 
+
 @dataclass
 class QuicNetworkPathChallenge:
-    '''
+    """
     Can be received on differente path, not a problem according to the draft
-    '''
-    #is_validated: bool = False
+    """
+
+    # is_validated: bool = False
     local_challenge: Optional[bytes] = None
     remote_challenge: Optional[bytes] = None
 
@@ -1160,11 +1162,10 @@ class QuicConnection:
         self._logger.debug("Network path %s discovered", network_path.addr)
         return network_path
 
-    #TODO for now we only consider the last challenge
     def _find_network_challenge(self) -> QuicNetworkPathChallenge:
         # check existing network challenge
         for idx, network_chall in enumerate(self._network_challenges):
-            if idx == len(self._network_challenges)-1:
+            if idx == len(self._network_challenges) - 1:
                 return network_chall
 
         # new network path
@@ -1854,10 +1855,6 @@ class QuicConnection:
             context.quic_logger_frames.append(
                 self._quic_logger.encode_path_response_frame(data=data)
             )
-
-        self._logger.debug("path_response: %s - %s", data, context.network_challenge.local_challenge)
-        self._logger.debug("path_response: %s", context)
-
         if data != context.network_challenge.local_challenge:
             raise QuicConnectionError(
                 error_code=QuicErrorCode.PROTOCOL_VIOLATION,
@@ -1868,7 +1865,7 @@ class QuicConnection:
             "Network path %s validated by challenge", context.network_path.addr
         )
         context.network_path.is_validated = True
-	# endpoint can abandon any path validation for other addresses
+        # endpoint can abandon any path validation for other addresses
         self._network_challenges = [QuicNetworkPathChallenge()]
 
     def _handle_ping_frame(
@@ -2387,7 +2384,7 @@ class QuicConnection:
                 )
             if (
                 quic_transport_parameters.max_ack_delay is not None
-                and quic_transport_parameters.max_ack_delay >= 2 ** 14
+                and quic_transport_parameters.max_ack_delay >= 2**14
             ):
                 raise QuicConnectionError(
                     error_code=QuicErrorCode.TRANSPORT_PARAMETER_ERROR,
@@ -2548,7 +2545,11 @@ class QuicConnection:
             )
 
     def _write_application(
-        self, builder: QuicPacketBuilder, network_path: QuicNetworkPath, network_challenge: QuicNetworkPathChallenge,  now: float
+        self,
+        builder: QuicPacketBuilder,
+        network_path: QuicNetworkPath,
+        network_challenge: QuicNetworkPathChallenge,
+        now: float,
     ) -> None:
         crypto_stream: Optional[QuicStream] = None
         if self._cryptos[tls.Epoch.ONE_RTT].send.is_valid():
@@ -2591,7 +2592,7 @@ class QuicConnection:
                     )
                     network_challenge.local_challenge = challenge
                     if network_challenge not in self._network_challenges:
-                    	self._network_challenges.append(network_challenge)
+                        self._network_challenges.append(network_challenge)
 
                 # PATH RESPONSE
                 if network_challenge.remote_challenge is not None:

--- a/src/aioquic/quic/recovery.py
+++ b/src/aioquic/quic/recovery.py
@@ -215,7 +215,7 @@ class QuicPacketRecovery:
             not self.peer_completed_address_validation
             or sum(space.ack_eliciting_in_flight for space in self.spaces) > 0
         ):
-            timeout = self.get_probe_timeout() * (2 ** self._pto_count)
+            timeout = self.get_probe_timeout() * (2**self._pto_count)
             return self._time_of_last_sent_ack_eliciting_packet + timeout
 
         return None

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1983,7 +1983,7 @@ class QuicConnectionTest(TestCase):
 
         data = encode_transport_parameters(
             QuicTransportParameters(
-                max_ack_delay=2 ** 14,
+                max_ack_delay=2**14,
                 original_destination_connection_id=client.original_destination_connection_id,
             )
         )


### PR DESCRIPTION
> " Path validation succeeds when a PATH_RESPONSE frame is received that
>    contains the data that was sent in a previous PATH_CHALLENGE frame.
>    A PATH_RESPONSE frame received on any network path validates the path
>    on which the PATH_CHALLENGE was sent."

We try to modify the PATH_CHALLENGE part of the connection.py to follow this rule that we found with a testing tool Ivy. The problem before was that if the PATH_RESPONSE was received on a different path the challenge was considered as failed. 

JF & CC 