### PR TITLE
fix: H3 application ConnectionClose code value should be 256 and not 0

### DIFF
--- a/examples/http3_client.py
+++ b/examples/http3_client.py
@@ -16,7 +16,7 @@ import aioquic
 from aioquic.asyncio.client import connect
 from aioquic.asyncio.protocol import QuicConnectionProtocol
 from aioquic.h0.connection import H0_ALPN, H0Connection
-from aioquic.h3.connection import H3_ALPN, H3Connection
+from aioquic.h3.connection import H3_ALPN, ErrorCode, H3Connection
 from aioquic.h3.events import (
     DataReceived,
     H3Event,
@@ -398,6 +398,7 @@ async def run(
 
             # process http pushes
             process_http_pushes(client=client, include=include, output_dir=output_dir)
+        client._quic.close(error_code=ErrorCode.H3_NO_ERROR)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
It looks like h3 client is sending "Application ConnectionClose" with wire_code 0.
But https://tools.ietf.org/html/draft-ietf-quic-http-34#section-8.1
specifies that H3_NO_ERROR is 256, not 0.