### PR TITLE
Minimize usage of global variables in server example

### DIFF
--- a/examples/http3_server.py
+++ b/examples/http3_server.py
@@ -70,7 +70,7 @@ class HttpRequestHandler:
             )
 
     async def run_asgi(self, app: AsgiApplication) -> None:
-        await application(self.scope, self.receive, self.send)
+        await app(self.scope, self.receive, self.send)
 
     async def receive(self) -> Dict:
         return await self.queue.get()
@@ -161,7 +161,7 @@ class WebSocketHandler:
         self.queue.put_nowait({"type": "websocket.connect"})
 
         try:
-            await application(self.scope, self.receive, self.send)
+            await app(self.scope, self.receive, self.send)
         finally:
             if not self.closed:
                 await self.send({"type": "websocket.close", "code": 1000})


### PR DESCRIPTION
Minimize the usage of the `application` global variable by using the `app` local variable that is present in the `run_asgi()` method.