### PR TITLE
Fix mutable default arguments in http3_client example

### DIFF
--- a/examples/http3_client.py
+++ b/examples/http3_client.py
@@ -251,7 +251,7 @@ class HttpClient(QuicConnectionProtocol):
 async def perform_http_request(
     client: HttpClient,
     url: str,
-    data: str,
+    data: Optional[str],
     include: bool,
     output_dir: Optional[str],
 ) -> None:
@@ -349,7 +349,7 @@ def save_session_ticket(ticket: SessionTicket) -> None:
 async def run(
     configuration: QuicConfiguration,
     urls: List[str],
-    data: str,
+    data: Optional[str],
     include: bool,
     output_dir: Optional[str],
     local_port: int,

--- a/examples/http3_client.py
+++ b/examples/http3_client.py
@@ -140,9 +140,6 @@ class HttpClient(QuicConnectionProtocol):
         """
         Perform a GET request.
         """
-        if headers is None:
-            headers = {}
-
         return await self._request(
             HttpRequest(method="GET", url=URL(url), headers=headers)
         )
@@ -153,9 +150,6 @@ class HttpClient(QuicConnectionProtocol):
         """
         Perform a POST request.
         """
-        if headers is None:
-            headers = {}
-
         return await self._request(
             HttpRequest(method="POST", url=URL(url), content=data, headers=headers)
         )
@@ -166,9 +160,6 @@ class HttpClient(QuicConnectionProtocol):
         """
         Open a WebSocket.
         """
-        if subprotocols is None:
-            subprotocols = []
-
         request = HttpRequest(method="CONNECT", url=URL(url))
         stream_id = self._quic.get_next_available_stream_id()
         websocket = WebSocket(

--- a/examples/http3_client.py
+++ b/examples/http3_client.py
@@ -53,8 +53,15 @@ class URL:
 
 class HttpRequest:
     def __init__(
-        self, method: str, url: URL, content: bytes = b"", headers: Dict = {}
+        self,
+        method: str,
+        url: URL,
+        content: bytes = b"",
+        headers: Optional[Dict] = None,
     ) -> None:
+        if headers is None:
+            headers = {}
+
         self.content = content
         self.headers = headers
         self.method = method
@@ -129,26 +136,39 @@ class HttpClient(QuicConnectionProtocol):
         else:
             self._http = H3Connection(self._quic)
 
-    async def get(self, url: str, headers: Dict = {}) -> Deque[H3Event]:
+    async def get(self, url: str, headers: Optional[Dict] = None) -> Deque[H3Event]:
         """
         Perform a GET request.
         """
+        if headers is None:
+            headers = {}
+
         return await self._request(
             HttpRequest(method="GET", url=URL(url), headers=headers)
         )
 
-    async def post(self, url: str, data: bytes, headers: Dict = {}) -> Deque[H3Event]:
+    async def post(
+        self, url: str, data: bytes, headers: Optional[Dict] = None
+    ) -> Deque[H3Event]:
         """
         Perform a POST request.
         """
+        if headers is None:
+            headers = {}
+
         return await self._request(
             HttpRequest(method="POST", url=URL(url), content=data, headers=headers)
         )
 
-    async def websocket(self, url: str, subprotocols: List[str] = []) -> WebSocket:
+    async def websocket(
+        self, url: str, subprotocols: Optional[List[str]] = None
+    ) -> WebSocket:
         """
         Open a WebSocket.
         """
+        if subprotocols is None:
+            subprotocols = []
+
         request = HttpRequest(method="CONNECT", url=URL(url))
         stream_id = self._quic.get_next_available_stream_id()
         websocket = WebSocket(

--- a/examples/http3_client.py
+++ b/examples/http3_client.py
@@ -79,7 +79,7 @@ class WebSocket:
         self.transmit = transmit
         self.websocket = wsproto.Connection(wsproto.ConnectionType.CLIENT)
 
-    async def close(self, code=1000, reason="") -> None:
+    async def close(self, code: int = 1000, reason: str = "") -> None:
         """
         Perform the closing handshake.
         """


### PR DESCRIPTION
Fix usage of mutable default arguments.

For an explanation of why mutable default arguments are a bad practice, see https://docs.python-guide.org/writing/gotchas/#mutable-default-arguments.