### PR TITLE
Correct required connect headers

### DIFF
--- a/src/aioquic/h3/connection.py
+++ b/src/aioquic/h3/connection.py
@@ -285,7 +285,7 @@ def validate_request_headers(headers: Headers) -> None:
             # we use it for the WebSocket demo.
             (b":method", b":scheme", b":authority", b":path", b":protocol")
         ),
-        required_pseudo_headers=frozenset((b":method", b":scheme", b":path")),
+        required_pseudo_headers=frozenset((b":method", b":authority")),
     )
 
 

--- a/tests/test_h3.py
+++ b/tests/test_h3.py
@@ -1703,7 +1703,7 @@ class H3ParserTest(TestCase):
             validate_request_headers([(b":method", b"GET")])
         self.assertEqual(
             cm.exception.reason_phrase,
-            "Pseudo-headers [b':path', b':scheme'] are missing",
+            "Pseudo-headers [b':authority'] are missing",
         )
 
         # empty :authority pseudo-header for http/https


### PR DESCRIPTION
Based on the IETF spec for both CONNECT and CONNECT-UDP, the following header validation adjustments were made:

* `:scheme` and `:path` MUST be omitted
* `:authority` MUST? be present

https://quicwg.org/base-drafts/draft-ietf-quic-http.html#section-4.2
https://tools.ietf.org/id/draft-schinazi-masque-connect-udp-00.html#name-the-connect-udp-method

Based on these linked documents, while it's clear that `:scheme` and `:path` must be omitted in both cases, it's unclear if `:authority` is actually required or if that's just for HTTP/3. So perhaps some adjustments still need to be made, submitting here for your thoughts. Should `:authority` be validated or not?

Additionally, I was unable to get the examples to work using the documentation in the README, so I did not make any changes there and there's a possibility this PR will break that code.

```bash
$ venv/bin/pip install -e .
... (successful)
$ venv/bin/pip install aiofiles asgiref dnslib httpbin starlette wsproto
... (successful)
$ venv/bin/python examples/http3_client.py --ca-certs tests/pycacert.pem https://localhost:4433/
Traceback (most recent call last):
  File "examples/http3_client.py", line 12, in <module>
    import wsproto
ModuleNotFoundError: No module named 'wsproto'
```