### PR TITLE
Stream stop event

### DIFF
--- a/src/aioquic/quic/connection.py
+++ b/src/aioquic/quic/connection.py
@@ -2027,6 +2027,8 @@ class QuicConnection:
         # reset the stream
         stream = self._get_or_create_stream(frame_type, stream_id)
         stream.sender.reset(error_code=QuicErrorCode.NO_ERROR)
+        self._events.append(events.StreamStop(error_code=QuicErrorCode.NO_ERROR,
+                                              stream_id=stream_id))
 
     def _handle_stream_frame(
         self, context: QuicReceiveContext, frame_type: int, buf: Buffer

--- a/src/aioquic/quic/connection.py
+++ b/src/aioquic/quic/connection.py
@@ -2027,8 +2027,7 @@ class QuicConnection:
         # reset the stream
         stream = self._get_or_create_stream(frame_type, stream_id)
         stream.sender.reset(error_code=QuicErrorCode.NO_ERROR)
-        self._events.append(events.StreamStop(error_code=QuicErrorCode.NO_ERROR,
-                                              stream_id=stream_id))
+        self._events.append(events.StreamStop(error_code=error_code, stream_id=stream_id))
 
     def _handle_stream_frame(
         self, context: QuicReceiveContext, frame_type: int, buf: Buffer

--- a/src/aioquic/quic/connection.py
+++ b/src/aioquic/quic/connection.py
@@ -2027,7 +2027,9 @@ class QuicConnection:
         # reset the stream
         stream = self._get_or_create_stream(frame_type, stream_id)
         stream.sender.reset(error_code=QuicErrorCode.NO_ERROR)
-        self._events.append(events.StreamStop(error_code=error_code, stream_id=stream_id))
+        self._events.append(
+            events.StreamStop(error_code=error_code, stream_id=stream_id)
+        )
 
     def _handle_stream_frame(
         self, context: QuicReceiveContext, frame_type: int, buf: Buffer

--- a/src/aioquic/quic/events.py
+++ b/src/aioquic/quic/events.py
@@ -110,3 +110,16 @@ class StreamReset(QuicEvent):
 
     stream_id: int
     "The ID of the stream that was reset."
+
+
+@dataclass
+class StreamStop(QuicEvent):
+    """
+    The StreamStop event is fired when the remote peer closes a stream.
+    """
+
+    error_code: int
+    "The error code that triggered the stop."
+
+    stream_id: int
+    "The ID of the stream that was stopped."

--- a/src/aioquic/quic/events.py
+++ b/src/aioquic/quic/events.py
@@ -115,7 +115,8 @@ class StreamReset(QuicEvent):
 @dataclass
 class StreamStop(QuicEvent):
     """
-    The StreamStop event is fired when the remote peer closes a stream.
+    The StreamStop event is fired when the remote peer closes a stream that it
+    was receiving on.
     """
 
     error_code: int

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -30,6 +30,7 @@ from aioquic.quic.packet import (
 )
 from aioquic.quic.packet_builder import QuicDeliveryState, QuicPacketBuilder
 from aioquic.quic.recovery import QuicPacketPacer
+
 from .utils import (
     SERVER_CACERTFILE,
     SERVER_CERTFILE,

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -30,7 +30,6 @@ from aioquic.quic.packet import (
 )
 from aioquic.quic.packet_builder import QuicDeliveryState, QuicPacketBuilder
 from aioquic.quic.recovery import QuicPacketPacer
-
 from .utils import (
     SERVER_CACERTFILE,
     SERVER_CERTFILE,
@@ -1669,29 +1668,6 @@ class QuicConnectionTest(TestCase):
             event = client.next_event()
             self.assertIsNone(event)
 
-    def test_handle_stop_sending_frame(self):
-        stream_id = 0
-        with client_and_server() as (client, server):
-            # client creates bidirectional stream
-            client.send_stream_data(stream_id=stream_id, data=b"hello")
-            consume_events(client)
-
-            # client receives STOP_STREAM
-            client._handle_stop_sending_frame(
-                client_receive_context(client),
-                QuicFrameType.STOP_SENDING,
-                Buffer(
-                    data=encode_uint_var(stream_id)
-                    + encode_uint_var(QuicErrorCode.INTERNAL_ERROR)
-                    + encode_uint_var(0)
-                ),
-            )
-
-            event = client.next_event()
-            self.assertEqual(type(event), events.StreamStop)
-            self.assertEqual(event.error_code, QuicErrorCode.INTERNAL_ERROR)
-            self.assertEqual(event.stream_id, stream_id)
-
     def test_handle_retire_connection_id_frame(self):
         with client_and_server() as (client, server):
             self.assertEqual(
@@ -1757,16 +1733,27 @@ class QuicConnectionTest(TestCase):
             )
 
     def test_handle_stop_sending_frame(self):
+        stream_id = 0
         with client_and_server() as (client, server):
-            # client creates bidirectional stream 0
-            client.send_stream_data(stream_id=0, data=b"hello")
+            # client creates bidirectional stream
+            client.send_stream_data(stream_id=stream_id, data=b"hello")
+            consume_events(client)
 
-            # client receives STOP_SENDING
+            # client receives STOP_STREAM
             client._handle_stop_sending_frame(
                 client_receive_context(client),
                 QuicFrameType.STOP_SENDING,
-                Buffer(data=b"\x00\x11"),
+                Buffer(
+                    data=encode_uint_var(stream_id)
+                    + encode_uint_var(QuicErrorCode.INTERNAL_ERROR)
+                    + encode_uint_var(0)
+                ),
             )
+
+            event = client.next_event()
+            self.assertEqual(type(event), events.StreamStop)
+            self.assertEqual(event.error_code, QuicErrorCode.INTERNAL_ERROR)
+            self.assertEqual(event.stream_id, stream_id)
 
     def test_handle_stop_sending_frame_receive_only(self):
         with client_and_server() as (client, server):

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1740,7 +1740,7 @@ class QuicConnectionTest(TestCase):
             client.send_stream_data(stream_id=stream_id, data=b"hello")
             consume_events(client)
 
-            # client receives STOP_STREAM
+            # client receives STOP_SENDING
             client._handle_stop_sending_frame(
                 client_receive_context(client),
                 QuicFrameType.STOP_SENDING,


### PR DESCRIPTION
When we receive a stream stop we should propagate an event for client code.
https://datatracker.ietf.org/doc/html/draft-ietf-quic-transport-29#page-127