### PR TITLE
Support the latest draft of HTTP Datagrams

### DIFF
--- a/src/aioquic/h3/connection.py
+++ b/src/aioquic/h3/connection.py
@@ -1,7 +1,7 @@
 import logging
 import re
 from enum import Enum, IntEnum
-from typing import Dict, FrozenSet, Iterable, List, Optional, Set
+from typing import Dict, FrozenSet, List, Optional, Set
 
 import pylsqpack
 


### PR DESCRIPTION
This PR contains two changes:
 1. Accept connections with Settings: H3_DATAGRAM=2. Also send
    Settings: H3_DATAGRAM=2. The received and sent settings
    parameters are exposed.
 2. Define H3Capsule which represents the Capsule concept
    defined in [A].

A: https://datatracker.ietf.org/doc/html/draft-schinazi-masque-protocol

Fixes #228.