### PR TITLE
libssl-dev is a requirement

### DIFF
--- a/examples/README.rst
+++ b/examples/README.rst
@@ -5,6 +5,7 @@ After checking out the code using git you can run:
 
 .. code-block:: console
 
+   $ sudo apt install libssl-dev
    $ pip install -e .
    $ pip install asgiref dnslib httpbin starlette wsproto
 


### PR DESCRIPTION
When libssl-dev is not install on Linux:

$ python3 -m pip install -e .
...
src/aioquic/_crypto.c:4:10: fatal error: openssl/err.h: No such file or directory
        4 | #include <openssl/err.h>
          |          ^~~~~~~~~~~~~~~
    compilation terminated.
    error: command 'x86_64-linux-gnu-gcc' failed with exit status 1
    ----------------------------------------
ERROR: Command errored out with exit status 1: /usr/bin/python3 -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/home/user/aioquic/setup.py'"'"'; __file__='"'"'/home/user/aioquic/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' develop --no-deps --user --prefix= Check the logs for full command output