### PR TITLE
Updated README.rst for latest openssl@3 post install instructions.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -93,8 +93,8 @@ You will need to set some environment variables to link against OpenSSL:
 
 .. code-block:: console
 
-   $ export CFLAGS=-I/usr/local/opt/openssl/include
-   $ export LDFLAGS=-L/usr/local/opt/openssl/lib
+   $ export CPPFLAGS="-I/opt/homebrew/opt/openssl@3/include"
+   $ export LDFLAGS="-L/opt/homebrew/opt/openssl@3/lib" 
 
 Windows
 .......


### PR DESCRIPTION
Updated README.rst to reference latest brew install of openssl@3 post install environment variables (CPPFLAGS and LDFLAGS) link instructions as of 12.2021.