### PR TITLE
[package] fix macosx arm64 wheels

### DIFF
--- a/scripts/fetch-vendor.json
+++ b/scripts/fetch-vendor.json
@@ -1,3 +1,3 @@
 {
-    "urls": ["https://github.com/aiortc/aioquic-openssl/releases/download/1.1.1m-1/openssl-{platform}.tar.gz"]
+    "urls": ["https://github.com/aiortc/aioquic-openssl/releases/download/1.1.1m-2/openssl-{platform}.tar.gz"]
 }


### PR DESCRIPTION
Release 0.9.18 was pushed out linked against an incorrect OpenSSL build,
making the armd64 wheels unusable.