### PR TITLE
[package] update cryptography requirement to >= 3.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ setuptools.setup(
     packages=["aioquic", "aioquic.asyncio", "aioquic.h0", "aioquic.h3", "aioquic.quic"],
     install_requires=[
         "certifi",
-        "cryptography >= 2.5, < 4",
+        "cryptography >= 3.1, < 4",
         'dataclasses; python_version < "3.7"',
         "pylsqpack >= 0.3.3, < 0.4.0",
     ],

--- a/src/aioquic/quic/retry.py
+++ b/src/aioquic/quic/retry.py
@@ -1,7 +1,6 @@
 import ipaddress
 from typing import Tuple
 
-from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric import padding, rsa
 
@@ -16,9 +15,7 @@ def encode_address(addr: NetworkAddress) -> bytes:
 
 class QuicRetryTokenHandler:
     def __init__(self) -> None:
-        self._key = rsa.generate_private_key(
-            public_exponent=65537, key_size=1024, backend=default_backend()
-        )
+        self._key = rsa.generate_private_key(public_exponent=65537, key_size=1024)
 
     def create_token(
         self,

--- a/src/aioquic/tls.py
+++ b/src/aioquic/tls.py
@@ -172,14 +172,13 @@ def hkdf_expand_label(
         algorithm=algorithm,
         length=length,
         info=hkdf_label(label, hash_value, length),
-        backend=default_backend(),
     ).derive(secret)
 
 
 def hkdf_extract(
     algorithm: hashes.HashAlgorithm, salt: bytes, key_material: bytes
 ) -> bytes:
-    h = hmac.HMAC(salt, algorithm, backend=default_backend())
+    h = hmac.HMAC(salt, algorithm)
     h.update(key_material)
     return h.finalize()
 
@@ -190,9 +189,7 @@ def load_pem_private_key(
     """
     Load a PEM-encoded private key.
     """
-    return serialization.load_pem_private_key(
-        data, password=password, backend=default_backend()
-    )
+    return serialization.load_pem_private_key(data, password=password)
 
 
 def load_pem_x509_certificates(data: bytes) -> List[x509.Certificate]:
@@ -203,11 +200,7 @@ def load_pem_x509_certificates(data: bytes) -> List[x509.Certificate]:
     certificates = []
     for chunk in data.split(boundary):
         if chunk:
-            certificates.append(
-                x509.load_pem_x509_certificate(
-                    chunk + boundary, backend=default_backend()
-                )
-            )
+            certificates.append(x509.load_pem_x509_certificate(chunk + boundary))
     return certificates
 
 
@@ -971,7 +964,7 @@ class KeySchedule:
         self.algorithm = cipher_suite_hash(cipher_suite)
         self.cipher_suite = cipher_suite
         self.generation = 0
-        self.hash = hashes.Hash(self.algorithm, default_backend())
+        self.hash = hashes.Hash(self.algorithm)
         self.hash_empty_value = self.hash.copy().finalize()
         self.secret = bytes(self.algorithm.digest_size)
 
@@ -987,7 +980,7 @@ class KeySchedule:
             length=self.algorithm.digest_size,
         )
 
-        h = hmac.HMAC(hmac_key, algorithm=self.algorithm, backend=default_backend())
+        h = hmac.HMAC(hmac_key, algorithm=self.algorithm)
         h.update(self.hash.copy().finalize())
         return h.finalize()
 
@@ -1396,7 +1389,7 @@ class Context:
         for group in self._supported_groups:
             if group == Group.SECP256R1:
                 self._ec_private_key = ec.generate_private_key(
-                    GROUP_TO_CURVE[Group.SECP256R1](), default_backend()
+                    GROUP_TO_CURVE[Group.SECP256R1]()
                 )
                 key_share.append(encode_public_key(self._ec_private_key.public_key()))
                 supported_groups.append(Group.SECP256R1)
@@ -1562,12 +1555,10 @@ class Context:
         certificate = pull_certificate(input_buf)
 
         self._peer_certificate = x509.load_der_x509_certificate(
-            certificate.certificates[0][0], backend=default_backend()
+            certificate.certificates[0][0]
         )
         self._peer_certificate_chain = [
-            x509.load_der_x509_certificate(
-                certificate.certificates[i][0], backend=default_backend()
-            )
+            x509.load_der_x509_certificate(certificate.certificates[i][0])
             for i in range(1, len(certificate.certificates))
         ]
 
@@ -1799,7 +1790,7 @@ class Context:
                 break
             elif isinstance(peer_public_key, ec.EllipticCurvePublicKey):
                 self._ec_private_key = ec.generate_private_key(
-                    GROUP_TO_CURVE[key_share[0]](), default_backend()
+                    GROUP_TO_CURVE[key_share[0]]()
                 )
                 public_key = self._ec_private_key.public_key()
                 shared_key = self._ec_private_key.exchange(ec.ECDH(), peer_public_key)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -6,7 +6,6 @@ import os
 import sys
 
 from cryptography import x509
-from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric import ec, ed448, ed25519
 
@@ -40,12 +39,12 @@ def generate_certificate(*, alternative_names, common_name, hash_algorithm, key)
             ),
             critical=False,
         )
-    cert = builder.sign(key, hash_algorithm, default_backend())
+    cert = builder.sign(key, hash_algorithm)
     return cert, key
 
 
 def generate_ec_certificate(common_name, alternative_names=[], curve=ec.SECP256R1):
-    key = ec.generate_private_key(backend=default_backend(), curve=curve)
+    key = ec.generate_private_key(curve=curve)
     return generate_certificate(
         alternative_names=alternative_names,
         common_name=common_name,


### PR DESCRIPTION
This allows us to drop the "backend" argument to many calls.