### PR TITLE
[tls] use PyOpenSSL to validate certificate

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,8 @@ setuptools.setup(
     packages=["aioquic", "aioquic.asyncio", "aioquic.h0", "aioquic.h3", "aioquic.quic"],
     install_requires=[
         "certifi",
-        "cryptography >= 3.1, < 4",
+        "cryptography >= 3.1",
         "pylsqpack >= 0.3.3, < 0.4.0",
+        "pyopenssl >= 20",
     ],
 )

--- a/tests/test_tls.py
+++ b/tests/test_tls.py
@@ -1296,22 +1296,6 @@ class VerifyCertificateTest(TestCase):
                 server_name="localhost",
             )
 
-    @patch("aioquic.tls.lib.X509_STORE_new")
-    def test_verify_certificate_chain_internal_error(self, mock_store_new):
-        mock_store_new.return_value = tls.ffi.NULL
-
-        certificate, _ = generate_ec_certificate(
-            common_name="localhost", curve=ec.SECP256R1
-        )
-
-        with self.assertRaises(tls.AlertInternalError) as cm:
-            verify_certificate(
-                cadata=certificate.public_bytes(serialization.Encoding.PEM),
-                certificate=certificate,
-                server_name="localhost",
-            )
-        self.assertEqual(str(cm.exception), "OpenSSL call to X509_store_new failed")
-
     def test_verify_dates(self):
         certificate, _ = generate_ec_certificate(
             common_name="example.com", curve=ec.SECP256R1


### PR DESCRIPTION
We cannot depend on reaching into cryptography's internals to get a
handle on OpenSSL, so instead use PyOpenSSL.

This allows us to unpin our cryptography version.