### PR TITLE
Test continuous live streaming

### DIFF
--- a/examples/htdocs/script.js
+++ b/examples/htdocs/script.js
@@ -1,0 +1,20 @@
+var transport = new WebTransport('https://localhost:4433/wt');
+transport.closed.then(console.log, console.error);
+await transport.ready;
+var { readable, writable } = transport.datagrams;
+var number_of_datagrams_received = 0;
+readable
+  .pipeTo(
+    new WritableStream({
+      write(datagram) {
+        console.log({ number_of_datagrams_received, datagram });
+        ++number_of_datagrams_received;
+      },
+      close() {
+        console.log('closed');
+      },
+    })
+  )
+  .then(console.log, console.error);
+var writer = writable.getWriter();
+await writer.write(new Uint8Array([65]));

--- a/examples/http3_server.py
+++ b/examples/http3_server.py
@@ -27,6 +27,10 @@ from aioquic.quic.events import DatagramFrameReceived, ProtocolNegotiated, QuicE
 from aioquic.quic.logger import QuicFileLogger
 from aioquic.tls import SessionTicket
 
+from random import choice
+from string import digits
+import itertools
+
 try:
     import uvloop
 except ImportError:
@@ -303,7 +307,12 @@ class WebTransportHandler:
                 )
             end_stream = True
         elif message["type"] == "webtransport.datagram.send":
-            self.connection.send_datagram(flow_id=self.stream_id, data=message["data"])
+            print('Try to stream datagrams continuously...')
+            for chunk in iter(lambda: ''.join(choice(digits) for i in range(512)).encode(), b''):
+                if chunk is not None:
+                    self.connection.send_datagram(flow_id=self.stream_id, data=chunk) 
+                    self.transmit()
+            # self.connection.send_datagram(flow_id=self.stream_id, data=message["data"])
         elif message["type"] == "webtransport.stream.send":
             self.connection._quic.send_stream_data(
                 stream_id=message["stream"], data=message["data"]
@@ -315,7 +324,7 @@ class WebTransportHandler:
             )
         if end_stream:
             self.closed = True
-        self.transmit()
+        # self.transmit()
 
 
 Handler = Union[HttpRequestHandler, WebSocketHandler, WebTransportHandler]

--- a/examples/templates/index.html
+++ b/examples/templates/index.html
@@ -31,5 +31,6 @@
             </li>
             <li>There is also an <a href="/httpbin/">httpbin instance</a>.</li>
         </ul>
+    <script type="module" src="/script.js"></script>
     </body>
 </html>


### PR DESCRIPTION
This is a PR for https://github.com/aiortc/aioquic/issues/242.

I do not know how to fix the problem nor write tests for /tests.

What I do know is that the server only sends 28 datagrams.

Steps to reproduce:

- Follow the instructions at https://github.com/aiortc/aioquic/tree/main/examples#chromium-and-chrome-usage then navigate to https://localhost:4433/. I included the script (script.js) in htdocs.

Expected result:

- I write/send one (1) datagram to the server.
- The server writes datagrams to client until I tell it to stop with `writer.close()`

What actually happens:

- The server sends 28 datagrams to client then stops.
- `WebTransportError: Connection lost.` thrown twice.

![Screenshot_2022-02-05_09-21-10](https://user-images.githubusercontent.com/4174848/152652011-eab3de3f-9a97-4270-8cb8-ae66229ca43e.png)


What I am actually trying to do is stream media using aioquic and `WebTransport`. For that I need only send one (1) initial datagram telling the server what to stream, then read the datagrams until I call `writer.close()` or `transport.close()`. Very simple. 