### PR TITLE
Enable IPv4/IPv6 dual stack support on Windows

### DIFF
--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -349,6 +349,11 @@ class HighLevelTest(TestCase):
             self.assertEqual(response, b"gnip")
 
     @asynctest
+    async def test_connect_local_port_bind(self):
+        with self.assertRaises(OverflowError):
+            await self.run_client(local_port=-1, port=self.bogus_port)
+
+    @asynctest
     async def test_change_connection_id(self):
         async with self.run_server() as server_port:
             configuration = QuicConfiguration(is_client=True)


### PR DESCRIPTION
Actually, Windows supports dual stack sockets, but does not enable it by default.

Furthermore, I am curious about the incentive for the use of dual stack, which is inconsistent with [cpython](https://github.com/python/cpython/blob/8714b6fa27271035dd6dd3514e283f92d669321d/Lib/asyncio/base_events.py#L1494-L1502).


