### PR TITLE
[wheels] fix creating temporary directory for dependencies

### DIFF
--- a/scripts/fetch-vendor.py
+++ b/scripts/fetch-vendor.py
@@ -43,7 +43,7 @@ with open(args.config_file, "r") as fp:
 logging.info("Creating directory %s" % args.destination_dir)
 if os.path.exists(args.destination_dir):
     shutil.rmtree(args.destination_dir)
-os.mkdir(args.destination_dir)
+os.makedirs(args.destination_dir)
 
 for url_template in config["urls"]:
     tarball_url = url_template.replace("{platform}", get_platform())


### PR DESCRIPTION
cibuildwheel seems to have changed the temporary directory on Windows,
so C:\cibw is not guaranteed to exist.