### PR TITLE
[asyncio] optimize QUIC speed on Windows

### DIFF
--- a/src/aioquic/asyncio/protocol.py
+++ b/src/aioquic/asyncio/protocol.py
@@ -1,5 +1,4 @@
 import asyncio
-import time
 from typing import Any, Callable, Dict, Optional, Text, Tuple, Union, cast
 
 from ..quic import events
@@ -58,7 +57,7 @@ class QuicConnectionProtocol(asyncio.DatagramProtocol):
 
         This method can only be called for clients and a single time.
         """
-        self._quic.connect(addr, now=time.perf_counter())
+        self._quic.connect(addr, now=self._loop.time())
         self.transmit()
 
     async def create_stream(
@@ -100,7 +99,7 @@ class QuicConnectionProtocol(asyncio.DatagramProtocol):
         self._transmit_task = None
 
         # send datagrams
-        for data, addr in self._quic.datagrams_to_send(now=time.perf_counter()):
+        for data, addr in self._quic.datagrams_to_send(now=self._loop.time()):
             self._transport.sendto(data, addr)
 
         # re-arm timer
@@ -133,7 +132,7 @@ class QuicConnectionProtocol(asyncio.DatagramProtocol):
         self._transport = cast(asyncio.DatagramTransport, transport)
 
     def datagram_received(self, data: Union[bytes, Text], addr: NetworkAddress) -> None:
-        self._quic.receive_datagram(cast(bytes, data), addr, now=time.perf_counter())
+        self._quic.receive_datagram(cast(bytes, data), addr, now=self._loop.time())
         self._process_events()
         self.transmit()
 
@@ -170,7 +169,7 @@ class QuicConnectionProtocol(asyncio.DatagramProtocol):
         return reader, writer
 
     def _handle_timer(self) -> None:
-        now = max(self._timer_at, time.perf_counter())
+        now = max(self._timer_at, self._loop.time())
         self._timer = None
         self._timer_at = None
         self._quic.handle_timer(now=now)

--- a/src/aioquic/asyncio/protocol.py
+++ b/src/aioquic/asyncio/protocol.py
@@ -1,4 +1,5 @@
 import asyncio
+import time
 from typing import Any, Callable, Dict, Optional, Text, Tuple, Union, cast
 
 from ..quic import events
@@ -57,7 +58,7 @@ class QuicConnectionProtocol(asyncio.DatagramProtocol):
 
         This method can only be called for clients and a single time.
         """
-        self._quic.connect(addr, now=self._loop.time())
+        self._quic.connect(addr, now=time.perf_counter())
         self.transmit()
 
     async def create_stream(
@@ -99,7 +100,7 @@ class QuicConnectionProtocol(asyncio.DatagramProtocol):
         self._transmit_task = None
 
         # send datagrams
-        for data, addr in self._quic.datagrams_to_send(now=self._loop.time()):
+        for data, addr in self._quic.datagrams_to_send(now=time.perf_counter()):
             self._transport.sendto(data, addr)
 
         # re-arm timer
@@ -132,7 +133,7 @@ class QuicConnectionProtocol(asyncio.DatagramProtocol):
         self._transport = cast(asyncio.DatagramTransport, transport)
 
     def datagram_received(self, data: Union[bytes, Text], addr: NetworkAddress) -> None:
-        self._quic.receive_datagram(cast(bytes, data), addr, now=self._loop.time())
+        self._quic.receive_datagram(cast(bytes, data), addr, now=time.perf_counter())
         self._process_events()
         self.transmit()
 
@@ -169,7 +170,7 @@ class QuicConnectionProtocol(asyncio.DatagramProtocol):
         return reader, writer
 
     def _handle_timer(self) -> None:
-        now = max(self._timer_at, self._loop.time())
+        now = max(self._timer_at, time.perf_counter())
         self._timer = None
         self._timer_at = None
         self._quic.handle_timer(now=now)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -11,7 +11,6 @@ from cryptography.hazmat.primitives.asymmetric import ec, ed448, ed25519
 
 
 class EventLoopPolicy(asyncio.DefaultEventLoopPolicy):
-
     def new_event_loop(self):
         loop = super().new_event_loop()
         loop._clock_resolution = time.get_clock_info("perf_counter").resolution

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -14,7 +14,7 @@ class EventLoopPolicy(asyncio.DefaultEventLoopPolicy):
 
     def new_event_loop(self):
         loop = super().new_event_loop()
-        loop._clock_resolution = time.get_clock_info('perf_counter').resolution
+        loop._clock_resolution = time.get_clock_info("perf_counter").resolution
         loop.time = time.perf_counter
         return loop
 
@@ -100,5 +100,5 @@ SKIP_TESTS = frozenset(os.environ.get("AIOQUIC_SKIP_TESTS", "").split(","))
 if os.environ.get("AIOQUIC_DEBUG"):
     logging.basicConfig(level=logging.DEBUG)
 
-if time.get_clock_info('monotonic').resolution > 0.001:
+if time.get_clock_info("monotonic").resolution > 0.001:
     asyncio.set_event_loop_policy(EventLoopPolicy())


### PR DESCRIPTION
The speed of QUIC on Windows is more than 10 times faster when transferring a large file, e.g. 64 MiB.

Test file:
https://gist.github.com/msoxzw/290cca70170ea9f6082c153ce391eb47
https://gist.github.com/msoxzw/567b747e70e2bb69d52586680f0c3a78

Rational:
[`loop.time()`](
https://github.com/python/cpython/blob/f8dc6186d1857a19edd182277a9d78e6d6cc3787/Lib/asyncio/base_events.py#L697-705) calls `time.monotonic()`, but [its time resolution varies from 10 ns to 15 ms depending on operating systems](https://peps.python.org/pep-0418/#monotonic-clocks), the worst of which is Windows. Therefore, using `time.perf_counter()`, a clock with the highest available resolution, basically eliminates time resolution discrepancies among platforms. Additionally, operating systems except Windows is not affected, because [`time.perf_counter()`](https://peps.python.org/pep-0418/#time-perf-counter)  calls  `time.monotonic()` on them.

