### PR TITLE
http3_client: :path should not be empty

### DIFF
--- a/examples/http3_client.py
+++ b/examples/http3_client.py
@@ -45,7 +45,7 @@ class URL:
         parsed = urlparse(url)
 
         self.authority = parsed.netloc
-        self.full_path = parsed.path
+        self.full_path = parsed.path or "/"
         if parsed.query:
             self.full_path += "?" + parsed.query
         self.scheme = parsed.scheme


### PR DESCRIPTION
When URL parameter has no path, such as https://foo.com,
it sends `:path` with empty string, which violates
https://quicwg.org/base-drafts/draft-ietf-quic-http.html#section-4.1.1.1