### PR TITLE
docs(readme): HTTP/3 is standardized now

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,9 +30,9 @@ What is ``aioquic``?
 ``aioquic`` is a library for the QUIC network protocol in Python. It features
 a minimal TLS 1.3 implementation, a QUIC stack and an HTTP/3 stack.
 
-QUIC was standardised in RFC 9000, but HTTP/3 standardisation is still ongoing.
-``aioquic`` closely tracks the specification drafts and is regularly tested for
-interoperability against other `QUIC implementations`_.
+QUIC was standardised in `RFC 9000`_ and HTTP/3 in `RFC 9114`_.
+``aioquic`` is regularly tested for interoperability against other
+`QUIC implementations`_.
 
 To learn more about ``aioquic`` please `read the documentation`_.
 
@@ -51,9 +51,9 @@ different concurrency models.
 Features
 --------
 
-- QUIC stack conforming with RFC 9000
-- HTTP/3 stack conforming with draft-ietf-quic-http-34
-- minimal TLS 1.3 implementation
+- QUIC stack conforming with `RFC 9000`_
+- HTTP/3 stack conforming with `RFC 9114`_
+- minimal TLS 1.3 implementation conforming with `RFC 8446`_
 - IPv4 and IPv6 support
 - connection migration and NAT rebinding
 - logging TLS traffic secrets
@@ -129,3 +129,6 @@ License
 .. _cryptography: https://cryptography.io/
 .. _Chocolatey: https://chocolatey.org/
 .. _BSD license: https://aioquic.readthedocs.io/en/latest/license.html
+.. _RFC 8446: https://datatracker.ietf.org/doc/html/rfc8446
+.. _RFC 9000: https://datatracker.ietf.org/doc/html/rfc9000
+.. _RFC 9114: https://datatracker.ietf.org/doc/html/rfc9114

--- a/src/aioquic/h3/connection.py
+++ b/src/aioquic/h3/connection.py
@@ -74,7 +74,7 @@ class Setting(IntEnum):
     MAX_FIELD_SECTION_SIZE = 0x6
     QPACK_BLOCKED_STREAMS = 0x7
 
-    # https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-h3-websockets-02#section-5
+    # https://datatracker.ietf.org/doc/html/rfc9220#section-5
     ENABLE_CONNECT_PROTOCOL = 0x8
     # https://datatracker.ietf.org/doc/html/draft-ietf-masque-h3-datagram-05#section-9.1
     H3_DATAGRAM = 0xFFD277
@@ -82,7 +82,7 @@ class Setting(IntEnum):
     ENABLE_WEBTRANSPORT = 0x2B603742
 
     # Dummy setting to check it is correctly ignored by the peer.
-    # https://tools.ietf.org/html/draft-ietf-quic-http-34#section-7.2.4.1
+    # https://datatracker.ietf.org/doc/html/rfc9114#section-7.2.4.1
     DUMMY = 0x21
 
 

--- a/src/aioquic/quic/logger.py
+++ b/src/aioquic/quic/logger.py
@@ -37,10 +37,10 @@ class QuicLoggerTrace:
     """
     A QUIC event trace.
 
-    Events are logged in the format defined by qlog draft-03.
+    Events are logged in the format defined by qlog.
 
     See:
-    - https://datatracker.ietf.org/doc/html/draft-ietf-quic-qlog-main-schema
+    - https://datatracker.ietf.org/doc/html/draft-ietf-quic-qlog-main-schema-02
     - https://datatracker.ietf.org/doc/html/draft-marx-quic-qlog-quic-events
     - https://datatracker.ietf.org/doc/html/draft-marx-quic-qlog-h3-events
     """
@@ -280,13 +280,7 @@ class QuicLoggerTrace:
 
 class QuicLogger:
     """
-    A QUIC event logger.
-
-    Serves as a container for traces in the format defined by qlog draft-03.
-
-    See:
-    - https://datatracker.ietf.org/doc/html/draft-marx-qlog-main-schema-03
-    - https://datatracker.ietf.org/doc/html/draft-marx-qlog-event-definitions-quic-h3-02
+    A QUIC event logger which stores traces in memory.
     """
 
     def __init__(self) -> None:

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -15,7 +15,7 @@ from .utils import SKIP_TESTS
 
 PROTOCOL_VERSION = QuicProtocolVersion.VERSION_1
 
-# https://tools.ietf.org/html/draft-ietf-quic-tls-34#appendix-A.5
+# https://datatracker.ietf.org/doc/html/rfc9001#appendix-A.5
 CHACHA20_CLIENT_PACKET_NUMBER = 654360564
 CHACHA20_CLIENT_PLAIN_HEADER = binascii.unhexlify("4200bff4")
 CHACHA20_CLIENT_PLAIN_PAYLOAD = binascii.unhexlify("01")
@@ -23,7 +23,7 @@ CHACHA20_CLIENT_ENCRYPTED_PACKET = binascii.unhexlify(
     "4cfe4189655e5cd55c41f69080575d7999c25a5bfb"
 )
 
-# https://tools.ietf.org/html/draft-ietf-quic-tls-34#appendix-A.2
+# https://datatracker.ietf.org/doc/html/rfc9001#appendix-A.2
 LONG_CLIENT_PACKET_NUMBER = 2
 LONG_CLIENT_PLAIN_HEADER = binascii.unhexlify(
     "c300000001088394c8f03e5157080000449e00000002"
@@ -79,7 +79,7 @@ LONG_CLIENT_ENCRYPTED_PACKET = binascii.unhexlify(
     "e221af44860018ab0856972e194cd934"
 )
 
-# https://tools.ietf.org/html/draft-ietf-quic-tls-34#appendix-A.3
+# https://datatracker.ietf.org/doc/html/rfc9001#appendix-A.3
 LONG_SERVER_PACKET_NUMBER = 1
 LONG_SERVER_PLAIN_HEADER = binascii.unhexlify(
     "c1000000010008f067a5502a4262b50040750001"
@@ -115,7 +115,7 @@ class CryptoTest(TestCase):
     """
     Test vectors from:
 
-    https://tools.ietf.org/html/draft-ietf-quic-tls-34#appendix-A
+    https://datatracker.ietf.org/doc/html/rfc9001#appendix-A
     """
 
     def create_crypto(self, is_client):
@@ -128,7 +128,7 @@ class CryptoTest(TestCase):
         return pair
 
     def test_derive_key_iv_hp(self):
-        # https://tools.ietf.org/html/draft-ietf-quic-tls-34#appendix-A.1
+        # https://datatracker.ietf.org/doc/html/rfc9001#appendix-A.1
 
         # client
         secret = binascii.unhexlify(
@@ -150,7 +150,7 @@ class CryptoTest(TestCase):
 
     @skipIf("chacha20" in SKIP_TESTS, "Skipping chacha20 tests")
     def test_derive_key_iv_hp_chacha20(self):
-        # https://tools.ietf.org/html/draft-ietf-quic-tls-34#appendix-A.5
+        # https://datatracker.ietf.org/doc/html/rfc9001#appendix-A.5
 
         # server
         secret = binascii.unhexlify(

--- a/tests/test_crypto_draft_29.py
+++ b/tests/test_crypto_draft_29.py
@@ -114,7 +114,7 @@ class CryptoTest(TestCase):
     """
     Test vectors from:
 
-    https://tools.ietf.org/html/draft-ietf-quic-tls-18#appendix-A
+    https://datatracker.ietf.org/doc/html/draft-ietf-quic-tls-18#appendix-A
     """
 
     def create_crypto(self, is_client):


### PR DESCRIPTION
https://datatracker.ietf.org/doc/html/rfc9114

Since June 6th 2022