### PR TITLE
Fix typos

### DIFF
--- a/examples/interop.py
+++ b/examples/interop.py
@@ -527,7 +527,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--server", type=str, help="only run against the specified server."
     )
-    parser.add_argument("--test", type=str, help="only run the specifed test.")
+    parser.add_argument("--test", type=str, help="only run the specified test.")
     parser.add_argument(
         "-l",
         "--secrets-log",

--- a/src/aioquic/quic/packet_builder.py
+++ b/src/aioquic/quic/packet_builder.py
@@ -338,7 +338,7 @@ class QuicPacketBuilder:
             if self._packet.in_flight:
                 self._datagram_flight_bytes += self._packet.sent_bytes
 
-            # short header packets cannot be coallesced, we need a new datagram
+            # short header packets cannot be coalesced, we need a new datagram
             if not self._packet_long_header:
                 self._flush_current_datagram()
 

--- a/src/aioquic/tls.py
+++ b/src/aioquic/tls.py
@@ -1819,7 +1819,7 @@ class Context:
                 max_early_data_size=self._max_early_data,
             )
 
-            # send messsage
+            # send message
             push_new_session_ticket(onertt_buf, self._new_session_ticket)
 
             # notify application

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1656,7 +1656,7 @@ class QuicConnectionTest(TestCase):
 
     def test_handle_path_response_frame_bad(self):
         with client_and_server() as (client, server):
-            # server receives unsollicited PATH_RESPONSE
+            # server receives unsolicited PATH_RESPONSE
             with self.assertRaises(QuicConnectionError) as cm:
                 server._handle_path_response_frame(
                     client_receive_context(client),

--- a/tests/test_h3.py
+++ b/tests/test_h3.py
@@ -796,7 +796,7 @@ class H3ConnectionTest(TestCase):
             )
             h3_server.send_data(stream_id=push_stream_id, data=b"text", end_stream=True)
 
-            # receive push promise / reponse
+            # receive push promise / response
             events = h3_transfer(quic_server, h3_client)
             self.assertEqual(
                 events,


### PR DESCRIPTION
Found via these command, `codespell . -L quicly`.