### PR TITLE
[logger] log packet_dropped with reason header_parse_error

### DIFF
--- a/src/aioquic/quic/connection.py
+++ b/src/aioquic/quic/connection.py
@@ -730,6 +730,15 @@ class QuicConnection:
                     buf, host_cid_length=self._configuration.connection_id_length
                 )
             except ValueError:
+                if self._quic_logger is not None:
+                    self._quic_logger.log_event(
+                        category="transport",
+                        event="packet_dropped",
+                        data={
+                            "trigger": "header_parse_error",
+                            "raw": {"length": buf.capacity - start_off},
+                        },
+                    )
                 return
 
             # check destination CID matches


### PR DESCRIPTION
Some servers add all zero padding to UDP datagrams during the handshake.

See also <https://github.com/quicwg/base-drafts/issues/3333>, one server with padding outside the QUIC packet is cloudflare/quiche. 