### PR TITLE
Update httpx example to support latest httpcore/httpx versions

### DIFF
--- a/examples/httpx_client.py
+++ b/examples/httpx_client.py
@@ -48,7 +48,7 @@ class H3Transport(QuicConnectionProtocol, httpx.AsyncHTTPTransport):
             headers=[
                 (b":method", request.method.encode()),
                 (b":scheme", request.url.raw_scheme),
-                (b":authority", request.url.raw_host),
+                (b":authority", request.url.netloc),
                 (b":path", request.url.raw_path),
             ]
             + [

--- a/examples/httpx_client.py
+++ b/examples/httpx_client.py
@@ -25,13 +25,10 @@ from aioquic.quic.logger import QuicFileLogger
 logger = logging.getLogger("client")
 
 
-class H3Transport(QuicConnectionProtocol, httpx.AsyncHTTPTransport):
+class H3Transport(QuicConnectionProtocol, httpx.AsyncBaseTransport):
     def __init__(self, *args, **kwargs):
-        QuicConnectionProtocol.__init__(self, *args, **kwargs)
-
-        # TODO: We must initialize the HTTPTransport but it is not clear
-        #       which arguments belong to it and which are for the other base
-        httpx.AsyncHTTPTransport.__init__(self)
+        # Initialize `QuicConnectionProtocol`; the base transport is just a protocol
+        super().__init__(*args, **kwargs)
 
         self._http = H3Connection(self._quic)
         self._read_queue: Dict[int, Deque[H3Event]] = {}
@@ -173,7 +170,7 @@ async def main(
         session_ticket_handler=save_session_ticket,
     ) as transport:
         async with AsyncClient(
-            transport=cast(httpx.AsyncHTTPTransport, transport)
+            transport=cast(httpx.AsyncBaseTransport, transport)
         ) as client:
             # perform request
             start = time.time()


### PR DESCRIPTION
Updates the httpx client transport example so the basic case works again. 

- The `httpcore` imports are in `httpx` now. 
- The request handler uses actual `Request` and `Response` types instead of tuples.

Tested with the examples from the README

```
❯ python examples/http3_server.py --certificate tests/ssl_cert.pem --private-key tests/ssl_key.pem
2022-09-26 21:52:40,577 INFO quic [acf386387b368251] ALPN negotiated protocol h3
2022-09-26 21:52:40,578 INFO quic [acf386387b368251] HTTP request GET /
2022-09-26 21:52:40,578 INFO quic [acf386387b368251] HTTP request GET /style.css
2022-09-26 21:52:40,585 INFO quic [acf386387b368251] Connection close received (code 0x0, reason )
```

```
❯ python examples/httpx_client.py --ca-certs tests/pycacert.pem -i https://localhost:4433/
2022-09-26 21:53:52,732 INFO quic [7f3cd4a02a7f8d16] ALPN negotiated protocol h3
2022-09-26 21:53:52,732 INFO client New session ticket received
2022-09-26 21:53:52,732 INFO quic [7f3cd4a02a7f8d16] Duplicate CRYPTO data received for epoch Epoch.HANDSHAKE
2022-09-26 21:53:52,733 INFO quic [7f3cd4a02a7f8d16] Duplicate CRYPTO data received for epoch Epoch.ONE_RTT
2022-09-26 21:53:52,736 INFO client Received 1276 bytes in 0.0 s (7.280 Mbps)
2022-09-26 21:53:52,736 INFO quic [7f3cd4a02a7f8d16] Connection close sent (code 0x0, reason )
```