### PR TITLE
Build abi3 wheels

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,6 +51,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python:
+          - "3.11"
           - "3.10"
           - "3.9"
           - "3.8"
@@ -93,6 +94,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: 3.7
+      - run: pip install wheel
       - name: Build source package
         run: python setup.py sdist
       - name: Upload source package

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 import os.path
 import sys
+from wheel.bdist_wheel import bdist_wheel
 
 import setuptools
 
@@ -20,6 +21,17 @@ if sys.platform == "win32":
 else:
     extra_compile_args = ["-std=c99"]
     libraries = ["crypto"]
+
+
+class bdist_wheel_abi3(bdist_wheel):
+    def get_tag(self):
+        python, abi, plat = super().get_tag()
+
+        if python.startswith("cp"):
+            return "cp37", "abi3", plat
+
+        return python, abi, plat
+
 
 setuptools.setup(
     name=about["__title__"],
@@ -43,6 +55,7 @@ setuptools.setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Topic :: Internet :: WWW/HTTP",
     ],
     ext_modules=[
@@ -50,14 +63,19 @@ setuptools.setup(
             "aioquic._buffer",
             extra_compile_args=extra_compile_args,
             sources=["src/aioquic/_buffer.c"],
+            define_macros=[("Py_LIMITED_API", "0x03070000")],
+            py_limited_api=True,
         ),
         setuptools.Extension(
             "aioquic._crypto",
             extra_compile_args=extra_compile_args,
             libraries=libraries,
             sources=["src/aioquic/_crypto.c"],
+            define_macros=[("Py_LIMITED_API", "0x03070000")],
+            py_limited_api=True,
         ),
     ],
+    cmdclass={"bdist_wheel": bdist_wheel_abi3},
     package_dir={"": "src"},
     package_data={"aioquic": ["py.typed", "_buffer.pyi", "_crypto.pyi"]},
     packages=["aioquic", "aioquic.asyncio", "aioquic.h0", "aioquic.h3", "aioquic.quic"],

--- a/src/aioquic/_buffer.c
+++ b/src/aioquic/_buffer.c
@@ -5,6 +5,12 @@
 
 #define MODULE_NAME "aioquic._buffer"
 
+// https://foss.heptapod.net/pypy/pypy/-/issues/3770
+#ifndef Py_None
+#define Py_None (&_Py_NoneStruct)
+#endif 
+
+
 static PyObject *BufferReadError;
 static PyObject *BufferWriteError;
 
@@ -14,6 +20,8 @@ typedef struct {
     uint8_t *end;
     uint8_t *pos;
 } BufferObject;
+
+static PyObject *BufferType;
 
 #define CHECK_READ_BOUNDS(self, len) \
     if (len < 0 || self->pos + len > self->end) { \
@@ -54,7 +62,10 @@ static void
 Buffer_dealloc(BufferObject *self)
 {
     free(self->base);
-    Py_TYPE(self)->tp_free((PyObject *) self);
+    PyTypeObject *tp = Py_TYPE(self);
+    freefunc free = PyType_GetSlot(tp, Py_tp_free);
+    free(self);
+    Py_DECREF(tp);
 }
 
 static PyObject *
@@ -360,44 +371,21 @@ static PyGetSetDef Buffer_getset[] = {
     {NULL}
 };
 
-static PyTypeObject BufferType = {
-    PyVarObject_HEAD_INIT(NULL, 0)
-    MODULE_NAME ".Buffer",              /* tp_name */
-    sizeof(BufferObject),               /* tp_basicsize */
-    0,                                  /* tp_itemsize */
-    (destructor)Buffer_dealloc,         /* tp_dealloc */
-    0,                                  /* tp_print */
-    0,                                  /* tp_getattr */
-    0,                                  /* tp_setattr */
-    0,                                  /* tp_reserved */
-    0,                                  /* tp_repr */
-    0,                                  /* tp_as_number */
-    0,                                  /* tp_as_sequence */
-    0,                                  /* tp_as_mapping */
-    0,                                  /* tp_hash  */
-    0,                                  /* tp_call */
-    0,                                  /* tp_str */
-    0,                                  /* tp_getattro */
-    0,                                  /* tp_setattro */
-    0,                                  /* tp_as_buffer */
-    Py_TPFLAGS_DEFAULT,                 /* tp_flags */
-    "Buffer objects",                   /* tp_doc */
-    0,                                  /* tp_traverse */
-    0,                                  /* tp_clear */
-    0,                                  /* tp_richcompare */
-    0,                                  /* tp_weaklistoffset */
-    0,                                  /* tp_iter */
-    0,                                  /* tp_iternext */
-    Buffer_methods,                     /* tp_methods */
-    0,                                  /* tp_members */
-    Buffer_getset,                      /* tp_getset */
-    0,                                  /* tp_base */
-    0,                                  /* tp_dict */
-    0,                                  /* tp_descr_get */
-    0,                                  /* tp_descr_set */
-    0,                                  /* tp_dictoffset */
-    (initproc)Buffer_init,              /* tp_init */
-    0,                                  /* tp_alloc */
+static PyType_Slot BufferType_slots[] = {
+    {Py_tp_dealloc, Buffer_dealloc},
+    {Py_tp_methods, Buffer_methods},
+    {Py_tp_doc, "Buffer objects"},
+    {Py_tp_getset, Buffer_getset},
+    {Py_tp_init, Buffer_init},
+    {0, 0},
+};
+
+static PyType_Spec BufferType_spec = {
+    MODULE_NAME ".Buffer",
+    sizeof(BufferObject),
+    0,
+    Py_TPFLAGS_DEFAULT,
+    BufferType_slots
 };
 
 
@@ -431,11 +419,14 @@ PyInit__buffer(void)
     Py_INCREF(BufferWriteError);
     PyModule_AddObject(m, "BufferWriteError", BufferWriteError);
 
-    BufferType.tp_new = PyType_GenericNew;
-    if (PyType_Ready(&BufferType) < 0)
+    BufferType = PyType_FromSpec(&BufferType_spec);
+    if (BufferType == NULL)
         return NULL;
-    Py_INCREF(&BufferType);
-    PyModule_AddObject(m, "Buffer", (PyObject *)&BufferType);
+
+    PyObject *o = PyType_FromSpec(&BufferType_spec);
+    if (o == NULL)
+        return NULL;
+    PyModule_AddObject(m, "Buffer", o);
 
     return m;
 }

--- a/src/aioquic/_crypto.c
+++ b/src/aioquic/_crypto.c
@@ -42,6 +42,8 @@ typedef struct {
     unsigned char nonce[AEAD_NONCE_LENGTH];
 } AEADObject;
 
+static PyObject *AEADType;
+
 static EVP_CIPHER_CTX *
 create_ctx(const EVP_CIPHER *cipher, int key_length, int operation)
 {
@@ -104,7 +106,10 @@ AEAD_dealloc(AEADObject *self)
 {
     EVP_CIPHER_CTX_free(self->decrypt_ctx);
     EVP_CIPHER_CTX_free(self->encrypt_ctx);
-    Py_TYPE(self)->tp_free((PyObject *) self);
+    PyTypeObject *tp = Py_TYPE(self);
+    freefunc free = PyType_GetSlot(tp, Py_tp_free);
+    free(self);
+    Py_DECREF(tp);
 }
 
 static PyObject*
@@ -195,45 +200,22 @@ static PyMethodDef AEAD_methods[] = {
     {NULL}
 };
 
-static PyTypeObject AEADType = {
-    PyVarObject_HEAD_INIT(NULL, 0)
-    MODULE_NAME ".AEAD",                /* tp_name */
-    sizeof(AEADObject),                 /* tp_basicsize */
-    0,                                  /* tp_itemsize */
-    (destructor)AEAD_dealloc,           /* tp_dealloc */
-    0,                                  /* tp_print */
-    0,                                  /* tp_getattr */
-    0,                                  /* tp_setattr */
-    0,                                  /* tp_reserved */
-    0,                                  /* tp_repr */
-    0,                                  /* tp_as_number */
-    0,                                  /* tp_as_sequence */
-    0,                                  /* tp_as_mapping */
-    0,                                  /* tp_hash  */
-    0,                                  /* tp_call */
-    0,                                  /* tp_str */
-    0,                                  /* tp_getattro */
-    0,                                  /* tp_setattro */
-    0,                                  /* tp_as_buffer */
-    Py_TPFLAGS_DEFAULT,                 /* tp_flags */
-    "AEAD objects",                     /* tp_doc */
-    0,                                  /* tp_traverse */
-    0,                                  /* tp_clear */
-    0,                                  /* tp_richcompare */
-    0,                                  /* tp_weaklistoffset */
-    0,                                  /* tp_iter */
-    0,                                  /* tp_iternext */
-    AEAD_methods,                       /* tp_methods */
-    0,                                  /* tp_members */
-    0,                                  /* tp_getset */
-    0,                                  /* tp_base */
-    0,                                  /* tp_dict */
-    0,                                  /* tp_descr_get */
-    0,                                  /* tp_descr_set */
-    0,                                  /* tp_dictoffset */
-    (initproc)AEAD_init,                /* tp_init */
-    0,                                  /* tp_alloc */
+static PyType_Slot AEADType_slots[] = {
+    {Py_tp_dealloc, AEAD_dealloc},
+    {Py_tp_methods, AEAD_methods},
+    {Py_tp_doc, "AEAD objects"},
+    {Py_tp_init, AEAD_init},
+    {0, 0},
 };
+
+static PyType_Spec AEADType_spec = {
+    MODULE_NAME ".AEADType",
+    sizeof(AEADObject),
+    0,
+    Py_TPFLAGS_DEFAULT,
+    AEADType_slots
+};
+
 
 /* HeaderProtection */
 
@@ -245,6 +227,8 @@ typedef struct {
     unsigned char mask[31];
     unsigned char zero[5];
 } HeaderProtectionObject;
+
+static PyObject *HeaderProtectionType;
 
 static int
 HeaderProtection_init(HeaderProtectionObject *self, PyObject *args, PyObject *kwargs)
@@ -286,7 +270,10 @@ static void
 HeaderProtection_dealloc(HeaderProtectionObject *self)
 {
     EVP_CIPHER_CTX_free(self->ctx);
-    Py_TYPE(self)->tp_free((PyObject *) self);
+    PyTypeObject *tp = Py_TYPE(self);
+    freefunc free = PyType_GetSlot(tp, Py_tp_free);
+    free(self);
+    Py_DECREF(tp);
 }
 
 static int HeaderProtection_mask(HeaderProtectionObject *self, const unsigned char* sample)
@@ -369,46 +356,21 @@ static PyMethodDef HeaderProtection_methods[] = {
     {NULL}
 };
 
-static PyTypeObject HeaderProtectionType = {
-    PyVarObject_HEAD_INIT(NULL, 0)
-    MODULE_NAME ".HeaderProtection",    /* tp_name */
-    sizeof(HeaderProtectionObject),     /* tp_basicsize */
-    0,                                  /* tp_itemsize */
-    (destructor)HeaderProtection_dealloc,   /* tp_dealloc */
-    0,                                  /* tp_print */
-    0,                                  /* tp_getattr */
-    0,                                  /* tp_setattr */
-    0,                                  /* tp_reserved */
-    0,                                  /* tp_repr */
-    0,                                  /* tp_as_number */
-    0,                                  /* tp_as_sequence */
-    0,                                  /* tp_as_mapping */
-    0,                                  /* tp_hash  */
-    0,                                  /* tp_call */
-    0,                                  /* tp_str */
-    0,                                  /* tp_getattro */
-    0,                                  /* tp_setattro */
-    0,                                  /* tp_as_buffer */
-    Py_TPFLAGS_DEFAULT,                 /* tp_flags */
-    "HeaderProtection objects",         /* tp_doc */
-    0,                                  /* tp_traverse */
-    0,                                  /* tp_clear */
-    0,                                  /* tp_richcompare */
-    0,                                  /* tp_weaklistoffset */
-    0,                                  /* tp_iter */
-    0,                                  /* tp_iternext */
-    HeaderProtection_methods,           /* tp_methods */
-    0,                                  /* tp_members */
-    0,                                  /* tp_getset */
-    0,                                  /* tp_base */
-    0,                                  /* tp_dict */
-    0,                                  /* tp_descr_get */
-    0,                                  /* tp_descr_set */
-    0,                                  /* tp_dictoffset */
-    (initproc)HeaderProtection_init,    /* tp_init */
-    0,                                  /* tp_alloc */
+static PyType_Slot HeaderProtectionType_slots[] = {
+    {Py_tp_dealloc, HeaderProtection_dealloc},
+    {Py_tp_methods, HeaderProtection_methods},
+    {Py_tp_doc, "HeaderProtection objects"},
+    {Py_tp_init, HeaderProtection_init},
+    {0, 0},
 };
 
+static PyType_Spec HeaderProtectionType_spec = {
+    MODULE_NAME ".HeaderProtectionType",
+    sizeof(HeaderProtectionObject),
+    0,
+    Py_TPFLAGS_DEFAULT,
+    HeaderProtectionType_slots
+};
 
 static struct PyModuleDef moduledef = {
     PyModuleDef_HEAD_INIT,
@@ -426,6 +388,7 @@ PyMODINIT_FUNC
 PyInit__crypto(void)
 {
     PyObject* m;
+    PyObject *o;
 
     m = PyModule_Create(&moduledef);
     if (m == NULL)
@@ -435,17 +398,23 @@ PyInit__crypto(void)
     Py_INCREF(CryptoError);
     PyModule_AddObject(m, "CryptoError", CryptoError);
 
-    AEADType.tp_new = PyType_GenericNew;
-    if (PyType_Ready(&AEADType) < 0)
+    AEADType = PyType_FromSpec(&AEADType_spec);
+    if (AEADType == NULL)
         return NULL;
-    Py_INCREF(&AEADType);
-    PyModule_AddObject(m, "AEAD", (PyObject *)&AEADType);
 
-    HeaderProtectionType.tp_new = PyType_GenericNew;
-    if (PyType_Ready(&HeaderProtectionType) < 0)
+    o = PyType_FromSpec(&AEADType_spec);
+    if (o == NULL)
         return NULL;
-    Py_INCREF(&HeaderProtectionType);
-    PyModule_AddObject(m, "HeaderProtection", (PyObject *)&HeaderProtectionType);
+    PyModule_AddObject(m, "AEAD", o);
+
+    HeaderProtectionType = PyType_FromSpec(&HeaderProtectionType_spec);
+    if (HeaderProtectionType == NULL)
+        return NULL;
+
+    o = PyType_FromSpec(&HeaderProtectionType_spec);
+    if (o == NULL)
+        return NULL;
+    PyModule_AddObject(m, "HeaderProtection", o);
 
     // ensure required ciphers are initialised
     EVP_add_cipher(EVP_aes_128_ecb());


### PR DESCRIPTION
Hi @jlaine,

First off thank you for the fantastic work you're doing here! 🍰  @meitinger has been working on HTTP/3 support for @mitmproxy over the summer and aioquic has worked out quite well for us. We're now close to merging it, but one blocking upstream issue is the lack of Python 3.11 wheels. 

To make sure this is not an issue for every upcoming Python version, this PR converts the aioquic C extensions to only use the Python Limited API and the puts the necessary tooling in place to build abi3 wheels (see https://cibuildwheel.readthedocs.io/en/stable/faq/#abi3). 

Code-wise I will say C is not my forte, but I have tried to switch to whatever https://github.com/python/cpython/blob/main/Modules/xxlimited.c or https://github.com/python/cpython/blob/3.7/Modules/xxlimited.c does. :)