### PR TITLE
Fix pyOpenSSL issue.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,9 +27,8 @@ classifiers = [
 ]
 dependencies = [
     "certifi",
-    "cryptography>=3.1,<39",
     "pylsqpack>=0.3.3,<0.4.0",
-    "pyopenssl>=20,<22",
+    "pyopenssl>=22",
 ]
 dynamic = ["version"]
 

--- a/src/aioquic/tls.py
+++ b/src/aioquic/tls.py
@@ -254,7 +254,7 @@ def verify_certificate(
     try:
         store_ctx.verify_certificate()
     except crypto.X509StoreContextError as exc:
-        raise AlertBadCertificate(exc.args[0][2])
+        raise AlertBadCertificate(exc.args[0])
 
 
 class CipherSuite(IntEnum):


### PR DESCRIPTION
pyOpenSSL >= 22 changed `X509StoreContextError` constructor, this PR takes that into account.
Related to #345, revert limitation set by 3930580b50831a034d21ee4689362188b21a4d6a.