### PR TITLE
Use function parameters instead of global arg values

### DIFF
--- a/examples/doq_server.py
+++ b/examples/doq_server.py
@@ -50,13 +50,13 @@ async def main(
     retry: bool,
 ) -> None:
     await serve(
-        args.host,
-        args.port,
+        host,
+        port,
         configuration=configuration,
         create_protocol=DnsServerProtocol,
         session_ticket_fetcher=session_ticket_store.pop,
         session_ticket_handler=session_ticket_store.add,
-        retry=args.retry,
+        retry=retry,
     )
     await asyncio.Future()
 

--- a/examples/http3_server.py
+++ b/examples/http3_server.py
@@ -483,13 +483,13 @@ async def main(
     retry: bool,
 ) -> None:
     await serve(
-        args.host,
-        args.port,
+        host,
+        port,
         configuration=configuration,
         create_protocol=HttpServerProtocol,
         session_ticket_fetcher=session_ticket_store.pop,
         session_ticket_handler=session_ticket_store.add,
-        retry=args.retry,
+        retry=retry,
     )
     await asyncio.Future()
 


### PR DESCRIPTION
Clean up example, which uses global variables and ignores parameters passed to the main function.