### PR TITLE
Fix AlertBadCertificate exception string

### DIFF
--- a/src/aioquic/tls.py
+++ b/src/aioquic/tls.py
@@ -254,7 +254,7 @@ def verify_certificate(
     try:
         store_ctx.verify_certificate()
     except crypto.X509StoreContextError as exc:
-        raise AlertBadCertificate(exc.args[0][2])
+        raise AlertBadCertificate(exc.args[0])
 
 
 class CipherSuite(IntEnum):


### PR DESCRIPTION
```
INFO quic [a05bd6a1b3ce138b] Connection close sent (code 0x12A, reason r)
```

becomes

```
INFO quic [a05bd6a1b3ce138b] Connection close sent (code 0x12A, reason certificate signature failure)
```