### PR TITLE
[tls] Match server_name against SAN IPAddress

### DIFF
--- a/src/aioquic/tls.py
+++ b/src/aioquic/tls.py
@@ -226,6 +226,8 @@ def verify_certificate(
                 for name in ext.value:
                     if isinstance(name, x509.DNSName):
                         subjectAltName.append(("DNS", name.value))
+                    elif isinstance(name, x509.IPAddress):
+                        subjectAltName.append(("IP Address", str(name.value)))
 
         try:
             ssl.match_hostname(


### PR DESCRIPTION
This simple change "works for me"; I think it could be useful to some, and worth adding if it does not introduce security holes, although I'm not 100% confident about that.  Do you prefer this as-is, or some sort of opt-in switch for this part?