### PR TITLE
Fix build on Windows (fixes: #383)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -71,8 +71,8 @@ jobs:
         if: matrix.os == 'windows-latest'
         run: |
           choco install openssl --no-progress
-          echo "INCLUDE=C:\Progra~1\OpenSSL-Win64\include" >> $GITHUB_ENV
-          echo "LIB=C:\Progra~1\OpenSSL-Win64\lib" >> $GITHUB_ENV
+          echo "INCLUDE=C:\Progra~1\OpenSSL\include" >> $GITHUB_ENV
+          echo "LIB=C:\Progra~1\OpenSSL\lib" >> $GITHUB_ENV
         shell: bash
       - name: Run tests
         run: |

--- a/README.rst
+++ b/README.rst
@@ -109,8 +109,8 @@ You will need to set some environment variables to link against OpenSSL:
 
 .. code-block:: console
 
-  $Env:INCLUDE = "C:\Progra~1\OpenSSL-Win64\include"
-  $Env:LIB = "C:\Progra~1\OpenSSL-Win64\lib"
+  $Env:INCLUDE = "C:\Progra~1\OpenSSL\include"
+  $Env:LIB = "C:\Progra~1\OpenSSL\lib"
 
 Running the examples
 --------------------


### PR DESCRIPTION
Chocolatey has changed the path where the OpenSSL headers and libraries are installed, so adjust our environment variables.