### PR TITLE
Use `sphinxcontrib-trio` for documentation generation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -34,7 +34,7 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.intersphinx',
     'sphinx_autodoc_typehints',
-    'sphinxcontrib.asyncio',
+    'sphinxcontrib_trio',
 ]
 intersphinx_mapping = {
     'cryptography': ('https://cryptography.io/en/latest', None),

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -1,3 +1,3 @@
 cryptography
 sphinx_autodoc_typehints
-sphinxcontrib-asyncio
+sphinxcontrib-trio


### PR DESCRIPTION
The `sphinxcontrib-asyncio` package does not seem to be maintained anymore and does not work with Python version above 3.7.