### PR TITLE
Replace deprecated `ssl.match_hostname` method (fixes: #368)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "certifi",
     "pylsqpack>=0.3.3,<0.4.0",
     "pyopenssl>=22",
+    "service-identity>=23.1.0",
 ]
 dynamic = ["version"]
 

--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -149,19 +149,25 @@ class HighLevelTest(TestCase):
     @asynctest
     async def test_connect_and_serve_with_ec_certificate(self):
         await self._test_connect_and_serve_with_certificate(
-            *generate_ec_certificate(common_name="localhost")
+            *generate_ec_certificate(
+                alternative_names=["localhost"], common_name="localhost"
+            )
         )
 
     @asynctest
     async def test_connect_and_serve_with_ed25519_certificate(self):
         await self._test_connect_and_serve_with_certificate(
-            *generate_ed25519_certificate(common_name="localhost")
+            *generate_ed25519_certificate(
+                alternative_names=["localhost"], common_name="localhost"
+            )
         )
 
     @asynctest
     async def test_connect_and_serve_with_ed448_certificate(self):
         await self._test_connect_and_serve_with_certificate(
-            *generate_ed448_certificate(common_name="localhost")
+            *generate_ed448_certificate(
+                alternative_names=["localhost"], common_name="localhost"
+            )
         )
 
     @asynctest


### PR DESCRIPTION
The standard libraries's `ssl.match_hostname` method was marked as deprecated in Python 3.10. Rather than implementing this critical piece of code ourselves, make use of the Python Cryptographic Authority's `service-identity` package.

One notable behaviour change is that validation is performed *only* against the `subjectAltName` extension instead of the `commonName`. This is the same behaviour as web browsers use.