### PR TITLE
Add StopSendingReceived QUIC event

### DIFF
--- a/docs/quic.rst
+++ b/docs/quic.rst
@@ -44,6 +44,9 @@ Events
     .. autoclass:: PingAcknowledged
         :members:
 
+    .. autoclass:: StopSendingReceived
+        :members:
+
     .. autoclass:: StreamDataReceived
         :members:
 

--- a/src/aioquic/quic/connection.py
+++ b/src/aioquic/quic/connection.py
@@ -2070,6 +2070,10 @@ class QuicConnection:
         stream = self._get_or_create_stream(frame_type, stream_id)
         stream.sender.reset(error_code=QuicErrorCode.NO_ERROR)
 
+        self._events.append(
+            events.StopSendingReceived(error_code=error_code, stream_id=stream_id)
+        )
+
     def _handle_stream_frame(
         self, context: QuicReceiveContext, frame_type: int, buf: Buffer
     ) -> None:

--- a/src/aioquic/quic/events.py
+++ b/src/aioquic/quic/events.py
@@ -83,6 +83,20 @@ class ProtocolNegotiated(QuicEvent):
 
 
 @dataclass
+class StopSendingReceived(QuicEvent):
+    """
+    The StopSendingReceived event is fired when the remote peer requests
+    stopping data transmission on a stream.
+    """
+
+    error_code: int
+    "The error code that was sent from the peer."
+
+    stream_id: int
+    "The ID of the stream that the peer requested stopping data transmission."
+
+
+@dataclass
 class StreamDataReceived(QuicEvent):
     """
     The StreamDataReceived event is fired whenever data is received on a

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1922,6 +1922,19 @@ class QuicConnectionTest(TestCase):
                 Buffer(data=b"\x00\x11"),
             )
 
+            # check events
+            self.assertEqual(type(client.next_event()), events.ProtocolNegotiated)
+            self.assertEqual(type(client.next_event()), events.HandshakeCompleted)
+            for i in range(7):
+                self.assertEqual(type(client.next_event()), events.ConnectionIdIssued)
+
+            event = client.next_event()
+            self.assertEqual(type(event), events.StopSendingReceived)
+            self.assertEqual(event.stream_id, 0)
+            self.assertEqual(event.error_code, 0x11)
+
+            self.assertIsNone(client.next_event())
+
     def test_handle_stop_sending_frame_receive_only(self):
         with client_and_server() as (client, server):
             # server creates unidirectional stream 3


### PR DESCRIPTION
Section 2.4 of RFC9000 says that an application protocol can request to be informed of state changes on streams. Even though the state machines described in section 3 don't explicitly have state transitions regarding STOP_SENDING, an application protocol sometimes needs to know the reception of STOP_SENDING.

For example, WebTransport Web API defines the [cancel](https://w3c.github.io/webtransport/#webtransportreceivestream-cancel) algorithm that sends a STOP_SENDING. To write a test for the algorithm, a server needs to detect whether the peer sends a STOP_SENDING.

The `StopSendingReceived` event can be used for such purposes.