### PR TITLE
Raise RSA key size for retry token generator / validator

### DIFF
--- a/src/aioquic/quic/retry.py
+++ b/src/aioquic/quic/retry.py
@@ -15,7 +15,7 @@ def encode_address(addr: NetworkAddress) -> bytes:
 
 class QuicRetryTokenHandler:
     def __init__(self) -> None:
-        self._key = rsa.generate_private_key(public_exponent=65537, key_size=1024)
+        self._key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
 
     def create_token(
         self,

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -16,6 +16,7 @@ class QuicRetryTokenHandlerTest(TestCase):
             addr, original_destination_connection_id, retry_source_connection_id
         )
         self.assertIsNotNone(token)
+        self.assertEqual(len(token), 256)
 
         # validate token - ok
         self.assertEqual(


### PR DESCRIPTION
A 1024-bit key cannot be considered secure, so raise this to 2048 bits.

Fixes: #407