### PR TITLE
Close connection if client's first INITIAL contains no CRYPTO

### DIFF
--- a/src/aioquic/quic/connection.py
+++ b/src/aioquic/quic/connection.py
@@ -878,6 +878,7 @@ class QuicConnection:
                         )
                 return
 
+            crypto_frame_required = False
             network_path = self._find_network_path(addr)
 
             # server initialization
@@ -885,6 +886,7 @@ class QuicConnection:
                 assert (
                     header.packet_type == PACKET_TYPE_INITIAL
                 ), "first packet must be INITIAL"
+                crypto_frame_required = True
                 self._network_paths = [network_path]
                 self._version = QuicProtocolVersion(header.version)
                 self._initialize(header.destination_cid)
@@ -1012,7 +1014,7 @@ class QuicConnection:
             )
             try:
                 is_ack_eliciting, is_probing = self._payload_received(
-                    context, plain_payload
+                    context, plain_payload, crypto_frame_required=crypto_frame_required
                 )
             except QuicConnectionError as exc:
                 self._logger.warning(exc)
@@ -2281,13 +2283,17 @@ class QuicConnection:
             self._retire_connection_ids.append(sequence_number)
 
     def _payload_received(
-        self, context: QuicReceiveContext, plain: bytes
+        self,
+        context: QuicReceiveContext,
+        plain: bytes,
+        crypto_frame_required: bool = False,
     ) -> Tuple[bool, bool]:
         """
         Handle a QUIC packet payload.
         """
         buf = Buffer(data=plain)
 
+        crypto_frame_found = False
         frame_found = False
         is_ack_eliciting = False
         is_probing = None
@@ -2336,6 +2342,9 @@ class QuicConnection:
             # update ACK only / probing flags
             frame_found = True
 
+            if frame_type == QuicFrameType.CRYPTO:
+                crypto_frame_found = True
+
             if frame_type not in NON_ACK_ELICITING_FRAME_TYPES:
                 is_ack_eliciting = True
 
@@ -2349,6 +2358,15 @@ class QuicConnection:
                 error_code=QuicErrorCode.PROTOCOL_VIOLATION,
                 frame_type=QuicFrameType.PADDING,
                 reason_phrase="Packet contains no frames",
+            )
+
+        # RFC 9000 - 17.2.2. Initial Packet
+        # The first packet sent by a client always includes a CRYPTO frame.
+        if crypto_frame_required and not crypto_frame_found:
+            raise QuicConnectionError(
+                error_code=QuicErrorCode.PROTOCOL_VIOLATION,
+                frame_type=QuicFrameType.PADDING,
+                reason_phrase="Packet contains no CRYPTO frame",
             )
 
         return is_ack_eliciting, bool(is_probing)

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -794,6 +794,19 @@ class QuicConnectionTest(TestCase):
         self.assertFalse(server._handshake_done_pending)
         self.assertEqual(datagram_sizes(items), [224])
 
+    def test_connect_with_no_crypto_frame(self):
+        def patch(client):
+            """
+            Patch client to send PING instead of CRYPTO.
+            """
+            client._push_crypto_data = client._send_probe
+
+        with client_and_server(client_patch=patch) as (client, server):
+            self.assertEqual(
+                server._close_event.reason_phrase,
+                "Packet contains no CRYPTO frame",
+            )
+
     def test_connect_with_no_transport_parameters(self):
         def patch(client):
             """


### PR DESCRIPTION
According to section 17.2.2 of RFC 9000, the client's first INITIAL packet must contain a CRYPTO frame. Ensure this is indeed to case to avoid connections in a half-connected state.