### PR TITLE
Add explicit dependency on `cryptography` (fixes: #414)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ classifiers = [
 ]
 dependencies = [
     "certifi",
+    "cryptography",
     "pylsqpack>=0.3.3,<0.4.0",
     "pyopenssl>=22",
     "service-identity>=23.1.0",


### PR DESCRIPTION
Make it clear that we depend directly on the `crytography` package rather than relying on the transitive dependency via `pyopenssl`. We do not version the dependency in order to avoid clashing with the versioned dependency in `pyopenssl`.