### PR TITLE
[h3] Adapt datagram API for RFC 9297 (fixes: #420)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,14 +51,16 @@ different concurrency models.
 Features
 --------
 
-- QUIC stack conforming with `RFC 9000`_
-- HTTP/3 stack conforming with `RFC 9114`_
 - minimal TLS 1.3 implementation conforming with `RFC 8446`_
-- IPv4 and IPv6 support
-- connection migration and NAT rebinding
-- logging TLS traffic secrets
-- logging QUIC events in QLOG format
-- HTTP/3 server push support
+- QUIC stack conforming with `RFC 9000`_
+  * IPv4 and IPv6 support
+  * connection migration and NAT rebinding
+  * logging TLS traffic secrets
+  * logging QUIC events in QLOG format
+- HTTP/3 stack conforming with `RFC 9114`_
+  * server push support
+  * WebSocket bootstrapping conforming with `RFC 9220`_
+  * datagram support conforming with `RFC 9297`_
 
 Requirements
 ------------
@@ -132,3 +134,5 @@ License
 .. _RFC 8446: https://datatracker.ietf.org/doc/html/rfc8446
 .. _RFC 9000: https://datatracker.ietf.org/doc/html/rfc9000
 .. _RFC 9114: https://datatracker.ietf.org/doc/html/rfc9114
+.. _RFC 9220: https://datatracker.ietf.org/doc/html/rfc9220
+.. _RFC 9297: https://datatracker.ietf.org/doc/html/rfc9297

--- a/examples/http3_server.py
+++ b/examples/http3_server.py
@@ -302,7 +302,9 @@ class WebTransportHandler:
                 )
             end_stream = True
         elif message["type"] == "webtransport.datagram.send":
-            self.connection.send_datagram(flow_id=self.stream_id, data=message["data"])
+            self.connection.send_datagram(
+                stream_id=self.stream_id, data=message["data"]
+            )
         elif message["type"] == "webtransport.stream.send":
             self.connection._quic.send_stream_data(
                 stream_id=message["stream"], data=message["data"]
@@ -438,7 +440,7 @@ class HttpServerProtocol(QuicConnectionProtocol):
             handler = self._handlers[event.stream_id]
             handler.http_event_received(event)
         elif isinstance(event, DatagramReceived):
-            handler = self._handlers[event.flow_id]
+            handler = self._handlers[event.stream_id]
             handler.http_event_received(event)
         elif isinstance(event, WebTransportStreamDataReceived):
             handler = self._handlers[event.session_id]

--- a/src/aioquic/h3/events.py
+++ b/src/aioquic/h3/events.py
@@ -40,8 +40,8 @@ class DatagramReceived(H3Event):
     data: bytes
     "The data which was received."
 
-    flow_id: int
-    "The ID of the flow the data was received for."
+    stream_id: int
+    "The ID of the stream the data was received for."
 
 
 @dataclass

--- a/tests/test_webtransport.py
+++ b/tests/test_webtransport.py
@@ -282,13 +282,13 @@ class WebTransportTest(TestCase):
             session_id = self._make_session(h3_client, h3_server)
 
             # send datagram
-            h3_client.send_datagram(data=b"foo", flow_id=session_id)
+            h3_client.send_datagram(data=b"foo", stream_id=session_id)
 
             # receive datagram
             events = h3_transfer(quic_client, h3_server)
             self.assertEqual(
                 events,
-                [DatagramReceived(data=b"foo", flow_id=session_id)],
+                [DatagramReceived(data=b"foo", stream_id=session_id)],
             )
 
     def test_handle_datagram_truncated(self):
@@ -301,8 +301,5 @@ class WebTransportTest(TestCase):
         h3_server.handle_event(DatagramFrameReceived(data=b"\xff"))
         self.assertEqual(
             quic_server.closed,
-            (
-                ErrorCode.H3_GENERAL_PROTOCOL_ERROR,
-                "Could not parse flow ID",
-            ),
+            (ErrorCode.H3_DATAGRAM_ERROR, "Could not parse quarter stream ID"),
         )


### PR DESCRIPTION
Our HTTP/3 code dealing with datagrams dates back to before RFC 9297 was published. This is reflected in the the use of the `flow_id` terminology which no longer exists. Update the following interfaces:

- `h3.DatagramReceived` now has a `stream_id` attribute instead of `flow_id`
- `h3.Connection.send_datagram` now has a `stream_id` argument instead of `flow_id`

Encoding and decoding to / from quarter stream ID is handled by the connection, so the user does not need to multiply or divide by four.