### PR TITLE
Drop `httpbin` from HTTP/3 server demo

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -62,10 +62,20 @@ Features
    * WebSocket bootstrapping conforming with `RFC 9220`_
    * datagram support conforming with `RFC 9297`_
 
-Requirements
-------------
+Installing
+----------
 
-``aioquic`` requires Python 3.8 or better, and the OpenSSL development headers.
+The easiest way to install ``aioquic`` is to run:
+
+.. code:: bash
+
+    pip install aioquic
+
+Building from source
+--------------------
+
+If there are no wheels for your system or if you wish to build ``aioquic``
+from source you will need the OpenSSL development headers.
 
 Linux
 .....

--- a/examples/README.rst
+++ b/examples/README.rst
@@ -5,8 +5,7 @@ After checking out the code using git you can run:
 
 .. code-block:: console
 
-   pip install -e .
-   pip install asgiref dnslib "flask<2.2" httpbin starlette "werkzeug<2.1" wsproto
+   pip install . dnslib jinja2 starlette wsproto
 
 
 HTTP/3

--- a/examples/demo.py
+++ b/examples/demo.py
@@ -6,8 +6,6 @@ import datetime
 import os
 from urllib.parse import urlencode
 
-import httpbin
-from asgiref.wsgi import WsgiToAsgi
 from starlette.applications import Starlette
 from starlette.responses import PlainTextResponse, Response
 from starlette.routing import Mount, Route, WebSocketRoute
@@ -134,7 +132,6 @@ starlette = Starlette(
         Route("/", homepage),
         Route("/{size:int}", padding),
         Route("/echo", echo, methods=["POST"]),
-        Mount("/httpbin", WsgiToAsgi(httpbin.app)),
         Route("/logs", logs),
         WebSocketRoute("/ws", ws),
         Mount(STATIC_URL, StaticFiles(directory=STATIC_ROOT, html=True)),

--- a/examples/templates/index.html
+++ b/examples/templates/index.html
@@ -29,7 +29,6 @@
                 <strong>CONNECT /wt</strong> runs a WebTransport echo service.
                 You must set the <em>:protocol</em> pseudo-header to <em>"webtransport"</em>.
             </li>
-            <li>There is also an <a href="/httpbin/">httpbin instance</a>.</li>
         </ul>
     </body>
 </html>


### PR DESCRIPTION
The `httpbin` package just doesn't seem to be maintained and it suffers from dependency hell.