### PR TITLE
Remove utcnow() deprecation warning.

### DIFF
--- a/src/aioquic/tls.py
+++ b/src/aioquic/tls.py
@@ -63,7 +63,7 @@ T = TypeVar("T")
 #
 #     TypeError: can't compare offset-naive and offset-aware datetimes
 #
-# We must continue to make an explictly offset-naive timestamp.
+# We must continue to make an explicitly offset-naive timestamp.
 utcnow = partial(datetime.datetime.now, None)
 
 

--- a/src/aioquic/tls.py
+++ b/src/aioquic/tls.py
@@ -54,8 +54,17 @@ SERVER_CONTEXT_STRING = b"TLS 1.3, server CertificateVerify"
 
 T = TypeVar("T")
 
-# facilitate mocking for the test suite
-utcnow = datetime.datetime.utcnow
+# facilitate time mocking for the test suite
+#
+# Python 3.12 deprecates utcnow(), but we cannot do the recommended thing and replace
+# utcnow() with datetime.now(timezone.utc) as the datetime objects that the cryptography
+# x509 library puts in certificates do not have any timezone info.  If we try to
+# compare them with something that has timezone info we will get an exception:
+#
+#     TypeError: can't compare offset-naive and offset-aware datetimes
+#
+# We must continue to make an explictly offset-naive timestamp.
+utcnow = partial(datetime.datetime.now, None)
 
 
 class AlertDescription(IntEnum):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -32,14 +32,15 @@ def generate_certificate(*, alternative_names, common_name, hash_algorithm, key)
         [x509.NameAttribute(x509.NameOID.COMMON_NAME, common_name)]
     )
 
+    # See tls.py's comment about utcnow() for why we call now() with None below.
     builder = (
         x509.CertificateBuilder()
         .subject_name(subject)
         .issuer_name(issuer)
         .public_key(key.public_key())
         .serial_number(x509.random_serial_number())
-        .not_valid_before(datetime.datetime.utcnow())
-        .not_valid_after(datetime.datetime.utcnow() + datetime.timedelta(days=10))
+        .not_valid_before(datetime.datetime.now(None))
+        .not_valid_after(datetime.datetime.now(None) + datetime.timedelta(days=10))
     )
     if alternative_names:
         builder = builder.add_extension(


### PR DESCRIPTION
Python 3.12 deprecates utcnow(), but we cannot do the recommended thing and replace utcnow() with datetime.now(timezone.utc) as the datetime objects that the cryptography x509 library puts in certificates do not have any timezone info.  If we try to compare them with something that has timezone info we will get an exception:

    TypeError: can't compare offset-naive and offset-aware datetimes

We must continue to make an explictly offset-naive timestamp.