### PR TITLE
Explicitly track whether FIN has been acknowledged 

### DIFF
--- a/src/aioquic/quic/connection.py
+++ b/src/aioquic/quic/connection.py
@@ -3019,7 +3019,7 @@ class QuicConnection:
                 QuicFrameType.CRYPTO,
                 capacity=frame_overhead,
                 handler=stream.sender.on_data_delivery,
-                handler_args=(frame.offset, frame.offset + len(frame.data)),
+                handler_args=(frame.offset, frame.offset + len(frame.data), False),
             )
             buf.push_uint_var(frame.offset)
             buf.push_uint16(len(frame.data) | 0x4000)
@@ -3246,7 +3246,7 @@ class QuicConnection:
                 frame_type,
                 capacity=frame_overhead,
                 handler=stream.sender.on_data_delivery,
-                handler_args=(frame.offset, frame.offset + len(frame.data)),
+                handler_args=(frame.offset, frame.offset + len(frame.data), frame.fin),
             )
             buf.push_uint_var(stream.stream_id)
             if frame.offset:


### PR DESCRIPTION
A stream's sender part is only finished if all the data and the FIN have been acknowledged. Tracking the acknowledged data ranges is not sufficient to know whether the FIN has been acknowledged too, as the FIN may have been sent on its own. To fix this we need to explicitly keep track of whether the frame containing the FIN was acknowledged.
    
We also:
    
- Remove a bogus assignment of `QuicStreamSender.send_buffer_empty`, this should have been `QuicStreamSender.buffer_is_empty`.
- Only set `buffer_is_empty` to `False` when data or a FIN have been lost. This saves useless calls to `QuicStreamSender.get_frame()`.

This is an alternative to #439 