### PR TITLE
Ensure no data is sent after a stream reset

### DIFF
--- a/src/aioquic/quic/packet_builder.py
+++ b/src/aioquic/quic/packet_builder.py
@@ -27,7 +27,6 @@ QuicDeliveryHandler = Callable[..., None]
 class QuicDeliveryState(Enum):
     ACKED = 0
     LOST = 1
-    EXPIRED = 2
 
 
 @dataclass


### PR DESCRIPTION
Once a RESET has been requested on a stream, the stream's state is exclusively determined by the RESET being acknowledged. Ensure that we never send out any more data after a RESET being acknowledged, even if data is lost.