### PR TITLE
Adapt "no subjectaltname" test for service-identitity >= 24

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "cryptography",
     "pylsqpack>=0.3.3,<0.4.0",
     "pyopenssl>=22",
-    "service-identity>=23.1.0",
+    "service-identity>=24.1.0",
 ]
 dynamic = ["version"]
 

--- a/src/aioquic/tls.py
+++ b/src/aioquic/tls.py
@@ -244,10 +244,13 @@ def verify_certificate(
                     certificate, server_name
                 )
 
-        except service_identity.VerificationError as exc:
+        except (
+            service_identity.CertificateError,
+            service_identity.VerificationError,
+        ) as exc:
             patterns = service_identity.cryptography.extract_patterns(certificate)
             if len(patterns) == 0:
-                errmsg = "subject alternative name not found in the certificate"
+                errmsg = str(exc)
             elif len(patterns) == 1:
                 errmsg = f"hostname {server_name!r} doesn't match {patterns[0]!r}"
             else:

--- a/tests/test_tls.py
+++ b/tests/test_tls.py
@@ -1666,8 +1666,7 @@ class VerifyCertificateTest(TestCase):
                     cadata=cadata, certificate=certificate, server_name="example.com"
                 )
             self.assertEqual(
-                str(cm.exception),
-                "subject alternative name not found in the certificate",
+                str(cm.exception), "Certificate does not contain any `subjectAltName`s."
             )
 
     def test_verify_subject_with_subjaltname(self):


### PR DESCRIPTION
When a certificate contains no subjectAltName extension, `service-identity` now raises a `CertificateError` instead of a `VerificationError`.