### PR TITLE
ec.generate_private_key() is supposed to be given a curve instance.

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -53,7 +53,7 @@ def generate_certificate(*, alternative_names, common_name, hash_algorithm, key)
 
 
 def generate_ec_certificate(common_name, alternative_names=[], curve=ec.SECP256R1):
-    key = ec.generate_private_key(curve=curve)
+    key = ec.generate_private_key(curve=curve())
     return generate_certificate(
         alternative_names=alternative_names,
         common_name=common_name,


### PR DESCRIPTION
In this one place we gave a class instead, which Cryptography < 42.0.0 tolerates and fixes, but it will be deprecated in 42.0.0.