### PR TITLE
Update build instructions for homebrew users

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -106,8 +106,8 @@ You will need to set some environment variables to link against OpenSSL:
 
 .. code-block:: console
 
-   export CFLAGS=-I/usr/local/opt/openssl/include
-   export LDFLAGS=-L/usr/local/opt/openssl/lib
+   export CFLAGS=-I$(brew --prefix openssl)/include
+   export LDFLAGS=-L$(brew --prefix openssl)/lib
 
 Windows
 .......


### PR DESCRIPTION
The location where homebrew installs OpenSSL may change, so query the installation prefix using `brew --prefix openssl`.

Fixes: #56