### PR TITLE
Fairer stream write scheduling [#125].

### DIFF
--- a/src/aioquic/quic/connection.py
+++ b/src/aioquic/quic/connection.py
@@ -359,6 +359,7 @@ class QuicConnection:
         self._spin_highest_pn = 0
         self._state = QuicConnectionState.FIRSTFLIGHT
         self._streams: Dict[int, QuicStream] = {}
+        self._streams_queue: List[QuicStream] = []
         self._streams_blocked_bidi: List[QuicStream] = []
         self._streams_blocked_uni: List[QuicStream] = []
         self._streams_finished: Set[int] = set()
@@ -615,9 +616,11 @@ class QuicConnection:
                                 "packet_type": self._quic_logger.packet_type(
                                     packet.packet_type
                                 ),
-                                "scid": dump_cid(self.host_cid)
-                                if is_long_header(packet.packet_type)
-                                else "",
+                                "scid": (
+                                    dump_cid(self.host_cid)
+                                    if is_long_header(packet.packet_type)
+                                    else ""
+                                ),
                                 "dcid": dump_cid(self._peer_cid.cid),
                             },
                             "raw": {"length": packet.sent_bytes},
@@ -1333,6 +1336,7 @@ class QuicConnection:
                 max_stream_data_remote=max_stream_data_remote,
                 writable=not stream_is_unidirectional(stream_id),
             )
+            self._streams_queue.append(stream)
         return stream
 
     def _get_or_create_stream_for_send(self, stream_id: int) -> QuicStream:
@@ -1370,6 +1374,7 @@ class QuicConnection:
                 max_stream_data_remote=max_stream_data_remote,
                 readable=not is_unidirectional,
             )
+            self._streams_queue.append(stream)
             if is_unidirectional:
                 self._local_next_stream_id_uni = stream_id + 4
             else:
@@ -2631,9 +2636,11 @@ class QuicConnection:
             initial_source_connection_id=self._local_initial_source_connection_id,
             max_ack_delay=25,
             max_datagram_frame_size=self._configuration.max_datagram_frame_size,
-            quantum_readiness=b"Q" * SMALLEST_MAX_DATAGRAM_SIZE
-            if self._configuration.quantum_readiness_test
-            else None,
+            quantum_readiness=(
+                b"Q" * SMALLEST_MAX_DATAGRAM_SIZE
+                if self._configuration.quantum_readiness_test
+                else None
+            ),
             stateless_reset_token=self._host_cids[0].stateless_reset_token,
         )
         if not self._is_client:
@@ -2836,34 +2843,54 @@ class QuicConnection:
                 except QuicPacketBuilderStop:
                     break
 
-            for stream in list(self._streams.values()):
-                # if the stream is finished, discard it
-                if stream.is_finished:
-                    self._logger.debug("Stream %d discarded", stream.stream_id)
-                    self._streams.pop(stream.stream_id)
-                    self._streams_finished.add(stream.stream_id)
-                    continue
+            sent: Set[QuicStream] = set()
+            discarded: Set[QuicStream] = set()
+            try:
+                for stream in self._streams_queue:
+                    # if the stream is finished, discard it
+                    if stream.is_finished:
+                        self._logger.debug("Stream %d discarded", stream.stream_id)
+                        self._streams.pop(stream.stream_id)
+                        self._streams_finished.add(stream.stream_id)
+                        discarded.add(stream)
+                        continue
 
-                if stream.receiver.stop_pending:
-                    # STOP_SENDING
-                    self._write_stop_sending_frame(builder=builder, stream=stream)
+                    if stream.receiver.stop_pending:
+                        # STOP_SENDING
+                        self._write_stop_sending_frame(builder=builder, stream=stream)
 
-                if stream.sender.reset_pending:
-                    # RESET_STREAM
-                    self._write_reset_stream_frame(builder=builder, stream=stream)
-                elif not stream.is_blocked and not stream.sender.buffer_is_empty:
-                    # STREAM
-                    self._remote_max_data_used += self._write_stream_frame(
-                        builder=builder,
-                        space=space,
-                        stream=stream,
-                        max_offset=min(
-                            stream.sender.highest_offset
-                            + self._remote_max_data
-                            - self._remote_max_data_used,
-                            stream.max_stream_data_remote,
-                        ),
-                    )
+                    if stream.sender.reset_pending:
+                        # RESET_STREAM
+                        self._write_reset_stream_frame(builder=builder, stream=stream)
+                    elif not stream.is_blocked and not stream.sender.buffer_is_empty:
+                        # STREAM
+                        used = self._write_stream_frame(
+                            builder=builder,
+                            space=space,
+                            stream=stream,
+                            max_offset=min(
+                                stream.sender.highest_offset
+                                + self._remote_max_data
+                                - self._remote_max_data_used,
+                                stream.max_stream_data_remote,
+                            ),
+                        )
+                        self._remote_max_data_used += used
+                        if used > 0:
+                            sent.add(stream)
+
+            finally:
+                # Make a new stream service order, putting served ones at the end.
+                #
+                # This method of updating the streams queue ensures that discarded
+                # streams are removed and ones which sent are moved to the end even
+                # if an exception occurs in the loop.
+                self._streams_queue = [
+                    stream
+                    for stream in self._streams_queue
+                    if not (stream in discarded or stream in sent)
+                ]
+                self._streams_queue.extend(sent)
 
             if builder.packet_is_empty:
                 break


### PR DESCRIPTION
This greatly improves multiplexing and stream fairness in the use case from #125 with no significant cost (the run I'll show is slightly slower, but I think that could be measurement noise and if not it is small).  The idea is that we keep an ordering for the streams and every time we generate datagrams to send, we recompute the list, moving anyone who got stream data transmitted to the end.

All the tests pass for me.  There seems to be an intermittent loss of one line of coverage related to qlog that I don't understand; we'll see if it shows up in the CI.

Here the is before case, in the terminal and qvis:

<img width="891" alt="Screenshot 2024-02-25 at 17 33 33" src="https://github.com/aiortc/aioquic/assets/78507/268c9493-c760-4409-8d12-3efeeba8bbda">

<img width="1155" alt="Screenshot 2024-02-25 at 17 34 03" src="https://github.com/aiortc/aioquic/assets/78507/bc29d938-bdb1-4855-8be7-07ae56e51812">

And now the much nicer after case:

<img width="898" alt="Screenshot 2024-02-25 at 17 31 29" src="https://github.com/aiortc/aioquic/assets/78507/98b59d32-b96b-4b6c-91ac-d92e3e194d2e">

<img width="1177" alt="Screenshot 2024-02-25 at 17 32 09" src="https://github.com/aiortc/aioquic/assets/78507/502e84c7-c082-45c1-9fac-d0dcf1db5756">
