### PR TITLE
Only load certifi if no alternates have been specified. [#476]

### DIFF
--- a/src/aioquic/tls.py
+++ b/src/aioquic/tls.py
@@ -271,7 +271,11 @@ def verify_certificate(
 
     # load CAs
     store = crypto.X509Store()
-    store.load_locations(certifi.where())
+
+    if cadata is None and cafile is None and capath is None:
+        # Load defaults from certifi.
+        store.load_locations(certifi.where())
+
     if cadata is not None:
         for cert in load_pem_x509_certificates(cadata):
             store.add_cert(crypto.X509.from_cryptography(cert))


### PR DESCRIPTION
This makes tls.py only load the certifi CA info if no alternate CA configuration has been specified.