### PR TITLE
Only buffer up to 512 KiB of pending CRYPTO frames [#501].

### DIFF
--- a/src/aioquic/quic/stream.py
+++ b/src/aioquic/quic/stream.py
@@ -48,6 +48,9 @@ class QuicStreamReceiver:
             stream_id=self._stream_id,
         )
 
+    def starting_offset(self) -> int:
+        return self._buffer_start
+
     def handle_frame(
         self, frame: QuicStreamFrame
     ) -> Optional[events.StreamDataReceived]:


### PR DESCRIPTION
Address #501 by limiting the size required to buffer pending CRYPTO frames to 512 KiB.  I picked this size based on it being big enough for post-quantum crypto, but still not very big.  The limit applies to the amount of storage we need to allocate, not the size of inbound fragments, so e.g. a bunch of small fragment around the 512 KiB offset would still trigger as we use a contiguous buffer and the required size would exceed the limit.