### PR TITLE
Make `serve()` an async context manager

### DIFF
--- a/examples/doq_server.py
+++ b/examples/doq_server.py
@@ -49,7 +49,7 @@ async def main(
     session_ticket_store: SessionTicketStore,
     retry: bool,
 ) -> None:
-    await serve(
+    async with serve(
         host,
         port,
         configuration=configuration,
@@ -57,8 +57,8 @@ async def main(
         session_ticket_fetcher=session_ticket_store.pop,
         session_ticket_handler=session_ticket_store.add,
         retry=retry,
-    )
-    await asyncio.Future()
+    ):
+        await asyncio.Future()
 
 
 if __name__ == "__main__":

--- a/examples/http3_server.py
+++ b/examples/http3_server.py
@@ -487,7 +487,7 @@ async def main(
     session_ticket_store: SessionTicketStore,
     retry: bool,
 ) -> None:
-    await serve(
+    async with serve(
         host,
         port,
         configuration=configuration,
@@ -495,8 +495,8 @@ async def main(
         session_ticket_fetcher=session_ticket_store.pop,
         session_ticket_handler=session_ticket_store.add,
         retry=retry,
-    )
-    await asyncio.Future()
+    ):
+        await asyncio.Future()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
In order to get a clean shutdown of the asyncio-based QUIC server, we need to:

- Make the `QuicServer.close()` method async.
- Make the `serve()` method an async context manager.

See #513 