### PR TITLE
better backwards compatibility with older versions of cryptography

### DIFF
--- a/src/aioquic/tls.py
+++ b/src/aioquic/tls.py
@@ -227,9 +227,11 @@ def verify_certificate(
 ) -> None:
     # verify dates
     now = utcnow()
-    if now < certificate.not_valid_before_utc:
+    before = getattr(certificate, "not_valid_before_utc", 0) or certificate.not_valid_before.replace(tzinfo=datetime.timezone.utc)
+    if now < before:
         raise AlertCertificateExpired("Certificate is not valid yet")
-    if now > certificate.not_valid_after_utc:
+    after = getattr(certificate, "not_valid_after_utc", 0) or certificate.not_valid_after.replace(tzinfo=datetime.timezone.utc)
+    if now > after:
         raise AlertCertificateExpired("Certificate is no longer valid")
 
     # verify subject


### PR DESCRIPTION
Older versions don't have `not_valid_before_utc` or `not_valid_after_utc`.