### PR TITLE
Enable jump to source in docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,6 +24,7 @@ sys.path.append(os.path.abspath("./_ext"))
 extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.intersphinx",
+    "sphinx.ext.viewcode",
     "sphinx_autodoc_typehints",
     "sphinxcontrib_trio",
     "sphinx_aioquic",


### PR DESCRIPTION
Hi,

This enables jumping to the source code in the docs.

wdyt

example from another project of the `[source]` link in the rendered HTML:

![image](https://github.com/user-attachments/assets/8a40b00c-9d22-40bc-89bd-c29880a6eb98)
