### PR TITLE
Fix linter errors with recent ruff versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -118,8 +118,6 @@ jobs:
           - os: macos-latest
             arch: x86_64
           - os: ubuntu-latest
-            arch: aarch64
-          - os: ubuntu-latest
             arch: i686
           - os: ubuntu-latest
             arch: x86_64

--- a/examples/http3_server.py
+++ b/examples/http3_server.py
@@ -387,9 +387,9 @@ class HttpServerProtocol(QuicConnectionProtocol):
                     transmit=self.transmit,
                 )
             elif method == "CONNECT" and protocol == "webtransport":
-                assert isinstance(
-                    self._http, H3Connection
-                ), "WebTransport is only supported over HTTP/3"
+                assert isinstance(self._http, H3Connection), (
+                    "WebTransport is only supported over HTTP/3"
+                )
                 scope = {
                     "client": client,
                     "headers": headers,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,5 +64,8 @@ select = [
     "I",  # isort
 ]
 
+[tool.ruff.lint.isort]
+known-third-party = ["aioquic"]
+
 [tool.setuptools.dynamic]
 version = {attr = "aioquic.__version__"}

--- a/src/aioquic/h3/connection.py
+++ b/src/aioquic/h3/connection.py
@@ -4,7 +4,6 @@ from enum import Enum, IntEnum
 from typing import Dict, FrozenSet, List, Optional, Set
 
 import pylsqpack
-
 from aioquic.buffer import UINT_VAR_MAX_SIZE, Buffer, BufferReadError, encode_uint_var
 from aioquic.h3.events import (
     DatagramReceived,

--- a/src/aioquic/quic/connection.py
+++ b/src/aioquic/quic/connection.py
@@ -263,26 +263,26 @@ class QuicConnection:
             f"{SMALLEST_MAX_DATAGRAM_SIZE} bytes"
         )
         if configuration.is_client:
-            assert (
-                original_destination_connection_id is None
-            ), "Cannot set original_destination_connection_id for a client"
-            assert (
-                retry_source_connection_id is None
-            ), "Cannot set retry_source_connection_id for a client"
+            assert original_destination_connection_id is None, (
+                "Cannot set original_destination_connection_id for a client"
+            )
+            assert retry_source_connection_id is None, (
+                "Cannot set retry_source_connection_id for a client"
+            )
         else:
             assert token_handler is None, "Cannot set `token_handler` for a server"
-            assert (
-                configuration.token == b""
-            ), "Cannot set `configuration.token` for a server"
-            assert (
-                configuration.certificate is not None
-            ), "SSL certificate is required for a server"
-            assert (
-                configuration.private_key is not None
-            ), "SSL private key is required for a server"
-            assert (
-                original_destination_connection_id is not None
-            ), "original_destination_connection_id is required for a server"
+            assert configuration.token == b"", (
+                "Cannot set `configuration.token` for a server"
+            )
+            assert configuration.certificate is not None, (
+                "SSL certificate is required for a server"
+            )
+            assert configuration.private_key is not None, (
+                "SSL private key is required for a server"
+            )
+            assert original_destination_connection_id is not None, (
+                "original_destination_connection_id is required for a server"
+            )
 
         # configuration
         self._configuration = configuration
@@ -511,9 +511,9 @@ class QuicConnection:
         :param addr: The network address of the remote peer.
         :param now: The current time.
         """
-        assert (
-            self._is_client and not self._connect_called
-        ), "connect() can only be called for clients and a single time"
+        assert self._is_client and not self._connect_called, (
+            "connect() can only be called for clients and a single time"
+        )
         self._connect_called = True
 
         self._network_paths = [QuicNetworkPath(addr, is_validated=True)]
@@ -886,9 +886,9 @@ class QuicConnection:
 
             # Server initialization.
             if not self._is_client and self._state == QuicConnectionState.FIRSTFLIGHT:
-                assert (
-                    header.packet_type == QuicPacketType.INITIAL
-                ), "first packet must be INITIAL"
+                assert header.packet_type == QuicPacketType.INITIAL, (
+                    "first packet must be INITIAL"
+                )
                 crypto_frame_required = True
                 self._network_paths = [network_path]
                 self._version = header.version

--- a/src/aioquic/quic/stream.py
+++ b/src/aioquic/quic/stream.py
@@ -262,9 +262,9 @@ class QuicStreamSender:
         """
         # If the frame had the FIN bit set, its end MUST match otherwise
         # we have a programming error.
-        assert (
-            not fin or stop == self._buffer_fin
-        ), "on_data_delivered() was called with inconsistent fin / stop"
+        assert not fin or stop == self._buffer_fin, (
+            "on_data_delivered() was called with inconsistent fin / stop"
+        )
 
         # If a reset has been requested, stop processing data delivery.
         # The transition to the finished state only depends on the reset

--- a/src/aioquic/tls.py
+++ b/src/aioquic/tls.py
@@ -263,8 +263,7 @@ def verify_certificate(
             else:
                 patterns_repr = ", ".join(repr(pattern) for pattern in patterns)
                 errmsg = (
-                    f"hostname {server_name!r} doesn't match "
-                    f"either of {patterns_repr}"
+                    f"hostname {server_name!r} doesn't match either of {patterns_repr}"
                 )
 
             raise AlertBadCertificate(errmsg) from exc


### PR DESCRIPTION
Newer ruff versions end up re-ordering our own imports, so adjust the configuration to preserve the previous behaviour.