### PR TITLE
Build wheels for aarch64 natively, drop PyPy

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -117,6 +117,8 @@ jobs:
             arch: arm64
           - os: macos-latest
             arch: x86_64
+          - os: ubuntu-24.04-arm
+            arch: aarch64
           - os: ubuntu-latest
             arch: i686
           - os: ubuntu-latest
@@ -129,10 +131,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.8
-      - name: Install QEMU
-        if: matrix.os == 'ubuntu-latest'
-        uses: docker/setup-qemu-action@v3
+          python-version: 3.11
       - name: Build wheels
         env:
           CIBW_ARCHS: ${{ matrix.arch }}
@@ -140,10 +139,10 @@ jobs:
           CIBW_BEFORE_BUILD_WINDOWS: python scripts\fetch-vendor.py C:\cibw\vendor
           CIBW_ENVIRONMENT: AIOQUIC_SKIP_TESTS=ipv6,loss CFLAGS=-I/tmp/vendor/include LDFLAGS=-L/tmp/vendor/lib
           CIBW_ENVIRONMENT_WINDOWS: AIOQUIC_SKIP_TESTS=ipv6,loss INCLUDE=C:\\cibw\\vendor\\include LIB=C:\\cibw\\vendor\\lib
-          CIBW_SKIP: cp37-* pp37-* *-musllinux*
+          CIBW_SKIP: '*-musllinux* pp*'
           CIBW_TEST_COMMAND: python -m unittest discover -t {project} -s {project}/tests
-          # there are no wheels for cryptography on these platforms
-          CIBW_TEST_SKIP: "*-{manylinux_i686,win32} pp*"
+          # There are no binary wheels for cryptography on 32-bit platforms.
+          CIBW_TEST_SKIP: "*-{manylinux_i686,win32}"
         run: |
           pip install cibuildwheel
           cibuildwheel --output-dir dist


### PR DESCRIPTION
We can now use native aarch64 runners to build our Linux/aarch64 wheels.

Anticipate some changes for cibuildwheel 3:

- Use Python 3.11 to perform build.
- Stop building wheels for PyPY.