### PR TITLE
Fix readthedocs configuration

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,3 +10,6 @@ python:
     - method: pip
       path: .
     - requirements: requirements/doc.txt
+
+sphinx:
+  configuration: docs/conf.py


### PR DESCRIPTION
See:
https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/