### PR TITLE
Replace asyncio.get_event_loop() with asyncio.get_running_loop()

### DIFF
--- a/examples/interop.py
+++ b/examples/interop.py
@@ -348,7 +348,7 @@ async def test_nat_rebinding(server: Server, configuration: QuicConfiguration):
 
         # replace transport
         protocol._transport.close()
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         await loop.create_datagram_endpoint(lambda: protocol, local_addr=("::", 0))
 
         # cause more traffic
@@ -379,7 +379,7 @@ async def test_address_mobility(server: Server, configuration: QuicConfiguration
 
         # replace transport
         protocol._transport.close()
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         await loop.create_datagram_endpoint(lambda: protocol, local_addr=("::", 0))
 
         # change connection ID

--- a/src/aioquic/asyncio/client.py
+++ b/src/aioquic/asyncio/client.py
@@ -51,7 +51,7 @@ async def connect(
       0-RTT.
     * ``local_port`` is the UDP port number that this client wants to bind.
     """
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_running_loop()
     local_host = "::"
 
     # lookup remote address

--- a/src/aioquic/asyncio/protocol.py
+++ b/src/aioquic/asyncio/protocol.py
@@ -13,7 +13,7 @@ class QuicConnectionProtocol(asyncio.DatagramProtocol):
     def __init__(
         self, quic: QuicConnection, stream_handler: Optional[QuicStreamHandler] = None
     ):
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
 
         self._closed = asyncio.Event()
         self._connected = False

--- a/src/aioquic/asyncio/server.py
+++ b/src/aioquic/asyncio/server.py
@@ -32,7 +32,7 @@ class QuicServer(asyncio.DatagramProtocol):
     ) -> None:
         self._configuration = configuration
         self._create_protocol = create_protocol
-        self._loop = asyncio.get_event_loop()
+        self._loop = asyncio.get_running_loop()
         self._protocols: Dict[bytes, QuicConnectionProtocol] = {}
         self._session_ticket_fetcher = session_ticket_fetcher
         self._session_ticket_handler = session_ticket_handler
@@ -199,7 +199,7 @@ async def serve(
       and a :class:`asyncio.StreamWriter`.
     """
 
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_running_loop()
 
     _, protocol = await loop.create_datagram_endpoint(
         lambda: QuicServer(


### PR DESCRIPTION
Get running loop is preferred due to reduced complexity and known behaviour

https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.get_event_loop