### PR TITLE
Build wheels for musllinux

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -139,10 +139,10 @@ jobs:
           CIBW_BEFORE_BUILD_WINDOWS: python scripts\fetch-vendor.py C:\cibw\vendor
           CIBW_ENVIRONMENT: AIOQUIC_SKIP_TESTS=ipv6,loss CFLAGS=-I/tmp/vendor/include LDFLAGS=-L/tmp/vendor/lib
           CIBW_ENVIRONMENT_WINDOWS: AIOQUIC_SKIP_TESTS=ipv6,loss INCLUDE=C:\\cibw\\vendor\\include LIB=C:\\cibw\\vendor\\lib
-          CIBW_SKIP: '*-musllinux* pp*'
+          CIBW_SKIP: 'pp*'
           CIBW_TEST_COMMAND: python -m unittest discover -t {project} -s {project}/tests
           # There are no binary wheels for cryptography on 32-bit platforms.
-          CIBW_TEST_SKIP: "*-{manylinux_i686,win32}"
+          CIBW_TEST_SKIP: "*-{manylinux_i686,musllinux_i686,win32}"
         run: |
           pip install cibuildwheel
           cibuildwheel --output-dir dist

--- a/scripts/fetch-vendor.json
+++ b/scripts/fetch-vendor.json
@@ -1,3 +1,3 @@
 {
-    "urls": ["https://github.com/aiortc/aioquic-openssl/releases/download/3.4.0-1/openssl-{platform}.tar.gz"]
+    "urls": ["https://github.com/aiortc/aioquic-openssl/releases/download/3.4.1-1/openssl-{platform}.tar.gz"]
 }

--- a/scripts/fetch-vendor.py
+++ b/scripts/fetch-vendor.py
@@ -12,7 +12,10 @@ def get_platform():
     system = platform.system()
     machine = platform.machine()
     if system == "Linux":
-        return f"manylinux_{machine}"
+        if platform.libc_ver()[0] == "glibc":
+            return f"manylinux_{machine}"
+        else:
+            return f"musllinux_{machine}"
     elif system == "Darwin":
         # cibuildwheel sets ARCHFLAGS:
         # https://github.com/pypa/cibuildwheel/blob/5255155bc57eb6224354356df648dc42e31a0028/cibuildwheel/macos.py#L207-L220


### PR DESCRIPTION
We now have binary builds of OpenSSL for `musllinux`, which allows us to build wheels for this platform.