### PR TITLE
Added Upload file, Local-IP, Multi stream, QUIC v2  support

### DIFF
--- a/examples/README.rst
+++ b/examples/README.rst
@@ -29,6 +29,19 @@ You can run the example client to perform an HTTP/3 request:
 
   python examples/http3_client.py --ca-certs tests/pycacert.pem https://localhost:4433/
 
+To specify a local IP address for the client to bind to, use the ``--local-ip`` option.
+For example, to bind to ``192.168.1.100`` (replace with your actual local IP):
+
+.. code-block:: console
+
+  python examples/http3_client.py --ca-certs tests/pycacert.pem --local-ip 192.168.1.100 https://localhost:4433/
+
+The default local IP is "::" (any IPv6 or IPv4). For a full list of options, run:
+
+.. code-block:: console
+
+  python examples/http3_client.py --help
+
 Alternatively you can perform an HTTP/0.9 request:
 
 .. code-block:: console

--- a/examples/README.rst
+++ b/examples/README.rst
@@ -48,6 +48,13 @@ Alternatively you can perform an HTTP/0.9 request:
 
   python examples/http3_client.py --ca-certs tests/pycacert.pem --legacy-http https://localhost:4433/
 
+The client also supports QUIC v2. By default, the server will accept both QUIC v1 and v2.
+You can instruct the client to only use QUIC v2 and fail if the server does not support it:
+
+.. code-block:: console
+
+  python examples/http3_client.py --ca-certs tests/pycacert.pem --strictly-v2 https://localhost:4433/
+
 Note: Attempting to use methods like PUT or POST (e.g., for file uploads via `--upload-file`)
 with the `--legacy-http` option is not supported by the example server.
 The server will respond with an error message and close the stream.

--- a/examples/README.rst
+++ b/examples/README.rst
@@ -35,11 +35,58 @@ Alternatively you can perform an HTTP/0.9 request:
 
   python examples/http3_client.py --ca-certs tests/pycacert.pem --legacy-http https://localhost:4433/
 
+Note: Attempting to use methods like PUT or POST (e.g., for file uploads via `--upload-file`)
+with the `--legacy-http` option is not supported by the example server.
+The server will respond with an error message and close the stream.
+HTTP/0.9 is primarily designed for simple GET requests.
+
 You can also open a WebSocket over HTTP/3:
 
 .. code-block:: console
 
   python examples/http3_client.py --ca-certs tests/pycacert.pem wss://localhost:4433/ws
+
+File Uploads (using PUT)
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+The example client can also upload files to the server using the `PUT` method.
+The server must be configured with an upload directory, and the path in the URL
+will dictate where the file is saved within that directory.
+
+First, ensure the server is running and configured with an upload directory.
+For example, to save uploaded files into a directory named `my_server_uploads`
+(created in your current working directory):
+
+.. code-block:: console
+
+   python examples/http3_server.py --certificate tests/ssl_cert.pem --private-key tests/ssl_key.pem --upload-dir ./my_server_uploads
+
+Then, use `http3_client.py` with the `--upload-file` option to send a file.
+The URL path will determine the save location and name on the server, relative
+to the server's configured upload directory.
+
+.. code-block:: console
+
+  python examples/http3_client.py --ca-certs tests/ssl_cert.pem --upload-file ./localfile.txt https://localhost:4433/path/on_server/remote_filename.txt
+
+This command will upload `./localfile.txt` from your machine, and the server
+will save it as `path/on_server/remote_filename.txt` inside the
+`./my_server_uploads` directory (creating subdirectories like `path/on_server/`
+if they don't exist).
+
+*Important Note on Headers:* Currently, `http3_client.py` sends no `Content-Type`
+or `Content-Disposition` headers for uploads. This is a workaround for a
+suspected issue in the underlying `aioquic` library's H3 header processing.
+The server uses the URL path for the filename and infers the content type if needed.
+
+You can also upload files using `curl` with the `PUT` method (which `curl -T` uses):
+
+.. code-block:: console
+
+  curl -T ./localfile.txt https://localhost:4433/path/on_server/remote_filename.txt --http3 -k
+
+(The `-k` flag for `curl` allows it to work with self-signed certificates like the
+example `ssl_cert.pem`.)
 
 Chromium and Chrome usage
 .........................

--- a/examples/demo.py
+++ b/examples/demo.py
@@ -6,7 +6,9 @@ import datetime
 import os
 from urllib.parse import urlencode
 
+import aiofiles  # type: ignore
 from starlette.applications import Starlette
+from starlette.exceptions import HTTPException
 from starlette.responses import PlainTextResponse, Response
 from starlette.routing import Mount, Route, WebSocketRoute
 from starlette.staticfiles import StaticFiles
@@ -21,6 +23,11 @@ LOGS_PATH = os.path.join(STATIC_ROOT, "logs")
 QVIS_URL = "https://qvis.quictools.info/"
 
 templates = Jinja2Templates(directory=os.path.join(ROOT, "templates"))
+
+# Define UPLOAD_DIR using environment variable AIOQUIC_UPLOAD_DIR or a
+# default, and create it.
+UPLOAD_DIR = os.environ.get("AIOQUIC_UPLOAD_DIR", os.path.join(ROOT, "uploads"))
+os.makedirs(UPLOAD_DIR, exist_ok=True)
 
 
 async def homepage(request):
@@ -98,6 +105,59 @@ async def ws(websocket):
         pass
 
 
+async def handle_root_post_upload(request):
+    # Local imports are removed as os, aiofiles, PlainTextResponse, HTTPException
+    # are available at module level.
+
+    filepath = request.path_params["filepath"]
+    if filepath.startswith("upload/"):
+        filepath = filepath[len("upload/") :]
+        # Handle case where path is just "upload/".
+        if not filepath:  # e.g. if original path was "upload/"
+            # An empty filepath is handled by later sanitization.
+            pass
+
+    filepath = filepath.lstrip("/")  # This line remains as per instructions
+
+    abs_upload_dir = os.path.abspath(UPLOAD_DIR)
+
+    save_path = os.path.join(abs_upload_dir, filepath)
+    abs_save_path = os.path.abspath(save_path)
+
+    # Security Check
+    if os.path.commonprefix([abs_save_path, abs_upload_dir]) != abs_upload_dir:
+        raise HTTPException(
+            status_code=403, detail="Forbidden: Path traversal attempt."
+        )
+
+    try:
+        parent_dir = os.path.dirname(abs_save_path)
+        if parent_dir and not os.path.exists(parent_dir):
+            os.makedirs(parent_dir, exist_ok=True)
+
+        async with aiofiles.open(abs_save_path, "wb") as f:
+            async for chunk in request.stream():
+                await f.write(chunk)
+
+        file_size = os.path.getsize(abs_save_path)
+        response_text = (
+            f"File '{filepath}' uploaded successfully ({file_size} bytes).\n"
+            f"Saved at: {abs_save_path}"
+        )
+        return PlainTextResponse(response_text, status_code=200)
+    except HTTPException:
+        raise
+    except Exception as e:
+        print(f"Error during root dynamic file upload for {filepath}: {e}")  # KEEP THIS
+        # Log the full traceback for server-side debugging
+        import traceback  # KEEP THIS (if not already module level)
+
+        traceback.print_exc()  # KEEP THIS
+        raise HTTPException(
+            status_code=500, detail=f"Error uploading file '{filepath}': {str(e)}"
+        )
+
+
 async def wt(scope: Scope, receive: Receive, send: Send) -> None:
     """
     WebTransport echo endpoint.
@@ -131,9 +191,12 @@ starlette = Starlette(
     routes=[
         Route("/", homepage),
         Route("/{size:int}", padding),
-        Route("/echo", echo, methods=["POST"]),
+        Route("/echo", echo, methods=["POST"]),  # Specific POST
         Route("/logs", logs),
         WebSocketRoute("/ws", ws),
+        # Add the new root-level POST handler here
+        Route("/{filepath:path}", handle_root_post_upload, methods=["POST", "PUT"]),
+        # Catch-all for GET (and others if not matched)
         Mount(STATIC_URL, StaticFiles(directory=STATIC_ROOT, html=True)),
     ]
 )

--- a/examples/http3_client.py
+++ b/examples/http3_client.py
@@ -834,6 +834,12 @@ if __name__ == "__main__":
     )
 
     parser.add_argument(
+        "--strictly-v2",
+        action="store_true",
+        help="connect using only QUIC v2, fail if not supported",
+    )
+
+    parser.add_argument(
         "--output-dir",
         type=str,
         help="write downloaded files to this directory",
@@ -894,6 +900,9 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
+    if args.negotiate_v2 and args.strictly_v2:
+        parser.error("argument --strictly-v2: not allowed with argument --negotiate-v2")
+
     logging.basicConfig(
         format="%(asctime)s %(levelname)s %(name)s %(message)s",
         level=logging.DEBUG if args.verbose else logging.INFO,
@@ -927,6 +936,9 @@ if __name__ == "__main__":
             QuicProtocolVersion.VERSION_2,
             QuicProtocolVersion.VERSION_1,
         ]
+    elif args.strictly_v2:
+        configuration.original_version = QuicProtocolVersion.VERSION_2
+        configuration.supported_versions = [QuicProtocolVersion.VERSION_2]
     if args.quic_log:
         configuration.quic_logger = QuicFileLogger(args.quic_log)
     if args.secrets_log:

--- a/examples/http3_client.py
+++ b/examples/http3_client.py
@@ -154,6 +154,28 @@ class HttpClient(QuicConnectionProtocol):
             HttpRequest(method="POST", url=URL(url), content=data, headers=headers)
         )
 
+    async def upload(
+        self, url: str, file_path: str, headers: Optional[Dict] = None
+    ) -> Deque[H3Event]:
+        """
+        Perform a POST request to upload a file.
+        """
+        # Keep 'headers: Optional[Dict] = None' for compatibility, but ignore it
+        # for now.
+
+        # os module should be imported at the top of the file.
+        # basename = os.path.basename(file_path) # No longer needed for headers
+        minimal_headers: Dict[str, str] = {
+            # No "Content-Type"
+            # No "Content-Disposition"
+        }
+        # The 'headers' input parameter is deliberately ignored.
+
+        request = HttpRequest(
+            method="PUT", url=URL(url), content=b"", headers=minimal_headers
+        )
+        return await self._request(request, file_path=file_path)
+
     async def websocket(
         self, url: str, subprotocols: Optional[List[str]] = None
     ) -> WebSocket:
@@ -216,24 +238,63 @@ class HttpClient(QuicConnectionProtocol):
             for http_event in self._http.handle_event(event):
                 self.http_event_received(http_event)
 
-    async def _request(self, request: HttpRequest) -> Deque[H3Event]:
+    async def _request(
+        self, request: HttpRequest, file_path: Optional[str] = None
+    ) -> Deque[H3Event]:
         stream_id = self._quic.get_next_available_stream_id()
-        self._http.send_headers(
-            stream_id=stream_id,
-            headers=[
-                (b":method", request.method.encode()),
-                (b":scheme", request.url.scheme.encode()),
-                (b":authority", request.url.authority.encode()),
-                (b":path", request.url.full_path.encode()),
-                (b"user-agent", USER_AGENT.encode()),
-            ]
-            + [(k.encode(), v.encode()) for (k, v) in request.headers.items()],
-            end_stream=not request.content,
-        )
-        if request.content:
-            self._http.send_data(
-                stream_id=stream_id, data=request.content, end_stream=True
+
+        common_headers = [
+            (b":method", request.method.encode()),
+            (b":scheme", request.url.scheme.encode()),
+            (b":authority", request.url.authority.encode()),
+            (b":path", request.url.full_path.encode()),
+            (b"user-agent", USER_AGENT.encode()),
+        ] + [(k.encode(), v.encode()) for (k, v) in request.headers.items()]
+
+        if file_path:
+            # Sending a file
+            self._http.send_headers(
+                stream_id=stream_id,
+                headers=common_headers,
+                end_stream=False,  # Headers are not the end of the stream
             )
+
+            chunk_size = 4096
+            try:
+                with open(file_path, "rb") as f:
+                    while True:
+                        chunk = f.read(chunk_size)
+                        if not chunk:
+                            break  # End of file
+                        self._http.send_data(
+                            stream_id=stream_id, data=chunk, end_stream=False
+                        )
+                # After all chunks are sent, send an empty data frame with
+                # end_stream=True
+                self._http.send_data(stream_id=stream_id, data=b"", end_stream=True)
+            except FileNotFoundError:
+                # Handle file not found error appropriately.
+                # For now, we can log it or raise an exception.
+                # This example will simply not send data if file not found,
+                # but a real application should handle this more gracefully.
+                logger.error(f"File not found: {file_path}")
+                # We might want to send an error back to the client or close the stream.
+                # For simplicity, sending an empty data frame with end_stream=True
+                # to correctly terminate the stream.
+                self._http.send_data(stream_id=stream_id, data=b"", end_stream=True)
+
+        else:
+            # Original behavior: sending content from request.content
+            self._http.send_headers(
+                stream_id=stream_id,
+                headers=common_headers,
+                end_stream=not request.content,  # True if no content
+            )
+            if request.content:
+                self._http.send_data(
+                    stream_id=stream_id, data=request.content, end_stream=True
+                )
+            # If no request.content, headers with end_stream=True was already sent.
 
         waiter = self._loop.create_future()
         self._request_events[stream_id] = deque()
@@ -249,10 +310,16 @@ async def perform_http_request(
     data: Optional[str],
     include: bool,
     output_dir: Optional[str],
+    upload_file_path: Optional[str] = None,
 ) -> None:
     # perform request
     start = time.time()
-    if data is not None:
+    if upload_file_path:
+        # Pass empty headers for now, as per instruction.
+        # The `upload` method itself sets Content-Type to application/octet-stream.
+        http_events = await client.upload(url, file_path=upload_file_path, headers={})
+        method = "PUT"
+    elif data is not None:
         data_bytes = data.encode()
         http_events = await client.post(
             url,
@@ -269,10 +336,20 @@ async def perform_http_request(
     elapsed = time.time() - start
 
     # print speed
-    octets = 0
-    for http_event in http_events:
-        if isinstance(http_event, DataReceived):
-            octets += len(http_event.data)
+    # Check method and ensure upload_file_path is available
+    if method == "PUT" and upload_file_path:
+        try:
+            octets = os.path.getsize(upload_file_path)
+        except OSError as e:
+            logger.error(f"Could not get size of uploaded file {upload_file_path}: {e}")
+            # Fallback if file size can't be read (e.g. deleted post-send start)
+            octets = 0
+    else:  # For GET, POST, or if PUT somehow didn't have upload_file_path
+        octets = 0
+        for http_event in http_events:
+            if isinstance(http_event, DataReceived):
+                octets += len(http_event.data)
+
     logger.info(
         "Response received for %s %s : %d bytes in %.1f s (%.3f Mbps)"
         % (method, urlparse(url).path, octets, elapsed, octets * 8 / elapsed / 1000000)
@@ -353,6 +430,7 @@ async def main(
     output_dir: Optional[str],
     local_port: int,
     zero_rtt: bool,
+    upload_file: Optional[str] = None,
 ) -> None:
     # parse URL
     parsed = urlparse(urls[0])
@@ -415,9 +493,12 @@ async def main(
                 perform_http_request(
                     client=client,
                     url=url,
+                    # This data is already None if upload_file was specified
+                    # (handled in __main__)
                     data=data,
                     include=include,
                     output_dir=output_dir,
+                    upload_file_path=upload_file,
                 )
                 for url in urls
             ]
@@ -459,6 +540,11 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "-d", "--data", type=str, help="send the specified data in a POST request"
+    )
+    parser.add_argument(
+        "--upload-file",
+        type=str,
+        help="path to the file to upload (disables --data if used)",
     )
     parser.add_argument(
         "-i",
@@ -591,14 +677,22 @@ if __name__ == "__main__":
 
     if uvloop is not None:
         uvloop.install()
+    data_to_pass = args.data
+    if args.upload_file and args.data:
+        logger.warning(
+            "Both --data and --upload-file specified. --data will be ignored."
+        )
+        data_to_pass = None
+
     asyncio.run(
         main(
             configuration=configuration,
             urls=args.url,
-            data=args.data,
+            data=data_to_pass,
             include=args.include,
             output_dir=args.output_dir,
             local_port=args.local_port,
             zero_rtt=args.zero_rtt,
+            upload_file=args.upload_file,
         )
     )

--- a/examples/http3_client.py
+++ b/examples/http3_client.py
@@ -453,7 +453,7 @@ async def main(
     data: Optional[str],
     include: bool,
     output_dir: Optional[str],
-    local_ip: str, # Added local_ip
+    local_ip: str,  # Added local_ip
     local_port: int,
     zero_rtt: bool,
     upload_file: Optional[str] = None,
@@ -490,13 +490,13 @@ async def main(
         _p = urlparse(_p.geturl())
         urls[i] = _p.geturl()
 
-    async with _local_connect( # Changed to _local_connect
+    async with _local_connect(  # Changed to _local_connect
         host,
         port,
         configuration=configuration,
         create_protocol=HttpClient,
         session_ticket_handler=save_session_ticket,
-        local_host=local_ip, # Passed local_ip as local_host
+        local_host=local_ip,  # Passed local_ip as local_host
         local_port=local_port,
         # local_host="0.0.0.0", # Removed as it caused TypeError with aioquic 1.2.0
         wait_connected=not zero_rtt,
@@ -591,7 +591,7 @@ async def _local_connect(
     stream_handler: Optional[QuicStreamHandler] = None,
     token_handler: Optional[QuicTokenHandler] = None,
     wait_connected: bool = True,
-    local_host: str = "::", # Added parameter
+    local_host: str = "::",  # Added parameter
     local_port: int = 0,
 ) -> AsyncGenerator[QuicConnectionProtocol, None]:
     """
@@ -624,7 +624,6 @@ async def _local_connect(
     # Default to the first entry from getaddrinfo for the remote host.
     _r_addr_info = remote_infos[0]
 
-
     # prepare QUIC connection
     if configuration is None:
         configuration = QuicConfiguration(is_client=True)
@@ -651,8 +650,7 @@ async def _local_connect(
             sock.bind((local_host, local_port, 0, 0))  # Bind to "::"
         except OSError as e:
             logger.error(
-                f"Direct IPv6 bind for '::' failed: {e}. "
-                f"Falling back to getaddrinfo."
+                f"Direct IPv6 bind for '::' failed: {e}. Falling back to getaddrinfo."
             )
             last_exc = e  # Store exception in case fallback also fails
             if sock:
@@ -960,7 +958,7 @@ if __name__ == "__main__":
             data=data_to_pass,
             include=args.include,
             output_dir=args.output_dir,
-            local_ip=args.local_ip, # Pass local_ip
+            local_ip=args.local_ip,
             local_port=args.local_port,
             zero_rtt=args.zero_rtt,
             upload_file=args.upload_file,

--- a/examples/http3_client.py
+++ b/examples/http3_client.py
@@ -3,17 +3,31 @@ import asyncio
 import logging
 import os
 import pickle
+import socket
 import ssl
 import time
 from collections import deque
-from typing import BinaryIO, Callable, Deque, Dict, List, Optional, Union, cast
+from contextlib import asynccontextmanager
+from typing import (
+    AsyncGenerator,
+    BinaryIO,
+    Callable,
+    Deque,
+    Dict,
+    List,
+    Optional,
+    Union,
+    cast,
+)
 from urllib.parse import urlparse
 
 import aioquic
 import wsproto
 import wsproto.events
-from aioquic.asyncio.client import connect
-from aioquic.asyncio.protocol import QuicConnectionProtocol
+
+# Remove direct import of connect, as we will define a local version
+# from aioquic.asyncio.client import connect
+from aioquic.asyncio.protocol import QuicConnectionProtocol, QuicStreamHandler
 from aioquic.h0.connection import H0_ALPN, H0Connection
 from aioquic.h3.connection import H3_ALPN, ErrorCode, H3Connection
 from aioquic.h3.events import (
@@ -23,10 +37,11 @@ from aioquic.h3.events import (
     PushPromiseReceived,
 )
 from aioquic.quic.configuration import QuicConfiguration
+from aioquic.quic.connection import QuicConnection, QuicTokenHandler
 from aioquic.quic.events import QuicEvent
 from aioquic.quic.logger import QuicFileLogger
 from aioquic.quic.packet import QuicProtocolVersion
-from aioquic.tls import CipherSuite, SessionTicket
+from aioquic.tls import CipherSuite, SessionTicket, SessionTicketHandler
 
 try:
     import uvloop
@@ -438,6 +453,7 @@ async def main(
     data: Optional[str],
     include: bool,
     output_dir: Optional[str],
+    local_ip: str, # Added local_ip
     local_port: int,
     zero_rtt: bool,
     upload_file: Optional[str] = None,
@@ -474,12 +490,13 @@ async def main(
         _p = urlparse(_p.geturl())
         urls[i] = _p.geturl()
 
-    async with connect(
+    async with _local_connect( # Changed to _local_connect
         host,
         port,
         configuration=configuration,
         create_protocol=HttpClient,
         session_ticket_handler=save_session_ticket,
+        local_host=local_ip, # Passed local_ip as local_host
         local_port=local_port,
         # local_host="0.0.0.0", # Removed as it caused TypeError with aioquic 1.2.0
         wait_connected=not zero_rtt,
@@ -559,6 +576,194 @@ async def main(
             # process http pushes
             process_http_pushes(client=client, include=include, output_dir=output_dir)
         client.close(error_code=ErrorCode.H3_NO_ERROR)
+
+
+# Copied and modified from aioquic.asyncio.client.connect
+# Added local_host parameter and removed hardcoding
+@asynccontextmanager
+async def _local_connect(
+    host: str,
+    port: int,
+    *,
+    configuration: Optional[QuicConfiguration] = None,
+    create_protocol: Optional[Callable] = QuicConnectionProtocol,
+    session_ticket_handler: Optional[SessionTicketHandler] = None,
+    stream_handler: Optional[QuicStreamHandler] = None,
+    token_handler: Optional[QuicTokenHandler] = None,
+    wait_connected: bool = True,
+    local_host: str = "::", # Added parameter
+    local_port: int = 0,
+) -> AsyncGenerator[QuicConnectionProtocol, None]:
+    """
+    Connect to a QUIC server at the given `host` and `port`.
+    This is a modified version of aioquic.asyncio.client.connect
+    to support specifying the local_host.
+    """
+    loop = asyncio.get_running_loop()
+    # local_host is now a parameter
+
+    # lookup remote address
+    # We need to do this first to make sure the remote host is resolvable,
+    # otherwise we might create a socket unnecessarily.
+    try:
+        remote_infos = await loop.getaddrinfo(host, port, type=socket.SOCK_DGRAM)
+    except socket.gaierror as e:
+        logger.error(f"Error resolving remote address {host}:{port} - {e}")
+        raise
+
+    # Use the first resolved address for the remote connection
+    # Choose AF_INET6 if available, otherwise AF_INET
+    # This logic is simplified from the original which forces an
+    # IPv4-mapped IPv6 if addr is len 2
+    # For QUIC, an IPv6 socket is generally preferred if the system supports it.
+    # The actual connection logic in protocol.connect will handle the specifics.
+
+    # We will determine the final r_addr to use for connect() later,
+    # after the local socket's family is known.
+    # For now, just store the first resolved remote address info.
+    # Default to the first entry from getaddrinfo for the remote host.
+    _r_addr_info = remote_infos[0]
+
+
+    # prepare QUIC connection
+    if configuration is None:
+        configuration = QuicConfiguration(is_client=True)
+    if configuration.server_name is None:
+        configuration.server_name = host
+    connection = QuicConnection(
+        configuration=configuration,
+        session_ticket_handler=session_ticket_handler,
+        token_handler=token_handler,
+    )
+
+    # Create and bind the local socket
+    sock = None
+    last_exc = None
+
+    if local_host == "::":
+        try:
+            logger.debug(
+                f"Attempting direct IPv6 bind for local_host '::', port {local_port}"
+            )
+            sock = socket.socket(socket.AF_INET6, socket.SOCK_DGRAM)
+            if hasattr(socket, "IPV6_V6ONLY") and hasattr(socket, "IPPROTO_IPV6"):
+                sock.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 0)
+            sock.bind((local_host, local_port, 0, 0))  # Bind to "::"
+        except OSError as e:
+            logger.error(
+                f"Direct IPv6 bind for '::' failed: {e}. "
+                f"Falling back to getaddrinfo."
+            )
+            last_exc = e  # Store exception in case fallback also fails
+            if sock:
+                sock.close()
+            sock = None
+            # Fall through to getaddrinfo logic if direct "::" bind fails
+
+    if sock is None:  # If not '::' or if '::' direct bind failed
+        logger.debug(
+            f"Using getaddrinfo for local_host '{local_host}', port {local_port}"
+        )
+        try:
+            # Removed flags=socket.AI_PASSIVE
+            local_addrinfos = await loop.getaddrinfo(
+                local_host, local_port, type=socket.SOCK_DGRAM
+            )
+        except socket.gaierror as e:
+            logger.error(
+                f"Error resolving local_host '{local_host}':{local_port} - {e}"
+            )
+            # If '::' direct bind failed and getaddrinfo also failed for '::',
+            # re-raise initial error or this one
+            # Prioritize direct bind error for "::" if it happened
+            if last_exc and local_host == "::":
+                raise last_exc
+            raise
+
+        for res in local_addrinfos:
+            af, socktype, proto, canonname, sa = res
+            try:
+                logger.debug(
+                    f"Attempting to bind to {sa} (family {af}) via getaddrinfo"
+                )
+                sock = socket.socket(af, socktype, proto)
+                if af == socket.AF_INET6:
+                    # For IPv6, ensure dual-stack for wildcard if we didn't go
+                    # through the direct "::" path
+                    # For specific IPv6s from getaddrinfo, this might also be desired.
+                    # Check sockaddr's host part
+                    if sa[0] == "::" or sa[0].upper() == "0:0:0:0:0:0:0:0":
+                        if hasattr(socket, "IPV6_V6ONLY") and hasattr(
+                            socket, "IPPROTO_IPV6"
+                        ):
+                            logger.debug(f"Setting IPV6_V6ONLY=0 for {sa}")
+                            sock.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 0)
+                sock.bind(sa)
+                logger.debug(f"Successfully bound to {sa}")
+                last_exc = None  # Clear previous error on success
+                break  # Successfully bound
+            except OSError as exc:
+                logger.warning(f"Binding to {sa} failed: {exc}")
+                last_exc = exc
+                if sock is not None:
+                    sock.close()
+                sock = None
+                continue  # Try next address info
+
+        if sock is None:  # If loop completed and sock is still None
+            if last_exc is not None:
+                logger.error(
+                    f"Failed to bind to {local_host}:{local_port} after trying all "
+                    f"options - Last error: {last_exc}"
+                )
+                raise last_exc
+            else:
+                # This case means getaddrinfo returned no usable addresses
+                custom_error = OSError(
+                    f"Could not create/bind socket for {local_host}:{local_port} "
+                    f"(getaddrinfo yielded no usable address)"
+                )
+                logger.error(str(custom_error))
+                raise custom_error
+
+    # connect
+    logger.debug(f"Local socket bound: {sock.getsockname()}, family {sock.family}")
+    transport, protocol = await loop.create_datagram_endpoint(
+        lambda: create_protocol(connection, stream_handler=stream_handler),
+        sock=sock,
+    )
+    protocol = cast(QuicConnectionProtocol, protocol)
+    try:
+        # Determine the final remote address to use for connect()
+        # The sockaddr is (host, port, flowinfo, scopeid)
+        connect_to_addr = _r_addr_info[4]
+
+        # If our local socket is IPv6 and the remote address from getaddrinfo is IPv4,
+        # we need to convert the remote address to an IPv4-mapped IPv6 address.
+        #
+        # A common way to check if a sockaddr is IPv4 is by its length
+        # (2 for (host,port)) vs IPv6 (4 for (host,port,flowinfo,scopeid)).
+        # Or, more reliably, check the family from _r_addr_info[0]
+        remote_family = _r_addr_info[0]
+
+        if sock.family == socket.AF_INET6 and remote_family == socket.AF_INET:
+            # Convert IPv4 sockaddr to IPv4-mapped IPv6 sockaddr
+            # connect_to_addr is like ('1.2.3.4', 1234)
+            # We want ('::ffff:1.2.3.4', 1234, 0, 0)
+            connect_to_addr = ("::ffff:" + connect_to_addr[0], connect_to_addr[1], 0, 0)
+            logger.debug(
+                "Local socket is IPv6, remote is IPv4. Mapping remote to %s",
+                connect_to_addr,
+            )
+
+        protocol.connect(connect_to_addr, transmit=wait_connected)
+        if wait_connected:
+            await protocol.wait_connected()
+        yield protocol
+    finally:
+        protocol.close()
+        await protocol.wait_closed()
+        transport.close()
 
 
 if __name__ == "__main__":
@@ -677,6 +882,12 @@ if __name__ == "__main__":
         "--zero-rtt", action="store_true", help="try to send requests using 0-RTT"
     )
     parser.add_argument(
+        "--local-ip",
+        type=str,
+        default="::",
+        help="local IP address to bind for connections",
+    )
+    parser.add_argument(
         "--num-streams",
         type=int,
         default=1,
@@ -749,6 +960,7 @@ if __name__ == "__main__":
             data=data_to_pass,
             include=args.include,
             output_dir=args.output_dir,
+            local_ip=args.local_ip, # Pass local_ip
             local_port=args.local_port,
             zero_rtt=args.zero_rtt,
             upload_file=args.upload_file,

--- a/examples/http3_client.py
+++ b/examples/http3_client.py
@@ -160,11 +160,12 @@ class HttpClient(QuicConnectionProtocol):
         """
         Perform a POST request to upload a file.
         """
-        # Keep 'headers: Optional[Dict] = None' for compatibility, but ignore it
-        # for now.
+        # Keep 'headers: Optional[Dict] = None' for compatibility,
+        # but ignore it for now.
 
         # os module should be imported at the top of the file.
-        # basename = os.path.basename(file_path) # No longer needed for headers
+        # basename = os.path.basename(file_path)
+        # This line is no longer needed for headers
         minimal_headers: Dict[str, str] = {
             # No "Content-Type"
             # No "Content-Disposition"
@@ -241,6 +242,14 @@ class HttpClient(QuicConnectionProtocol):
     async def _request(
         self, request: HttpRequest, file_path: Optional[str] = None
     ) -> Deque[H3Event]:
+        if len(self._request_waiter) > 100:  # Threshold for warning
+            logger.warning(
+                (
+                    f"HttpClient has {len(self._request_waiter)} concurrent "
+                    "requests pending. Further stream creations might be delayed "
+                    "due to server-imposed concurrent stream limits."
+                )
+            )
         stream_id = self._quic.get_next_available_stream_id()
 
         common_headers = [
@@ -269,8 +278,8 @@ class HttpClient(QuicConnectionProtocol):
                         self._http.send_data(
                             stream_id=stream_id, data=chunk, end_stream=False
                         )
-                # After all chunks are sent, send an empty data frame with
-                # end_stream=True
+                # After all chunks are sent, send an empty data frame
+                # with end_stream=True
                 self._http.send_data(stream_id=stream_id, data=b"", end_stream=True)
             except FileNotFoundError:
                 # Handle file not found error appropriately.
@@ -285,10 +294,11 @@ class HttpClient(QuicConnectionProtocol):
 
         else:
             # Original behavior: sending content from request.content
+            # True if no content, False if content follows
             self._http.send_headers(
                 stream_id=stream_id,
                 headers=common_headers,
-                end_stream=not request.content,  # True if no content
+                end_stream=not request.content,
             )
             if request.content:
                 self._http.send_data(
@@ -431,6 +441,7 @@ async def main(
     local_port: int,
     zero_rtt: bool,
     upload_file: Optional[str] = None,
+    num_streams: int = 1,
 ) -> None:
     # parse URL
     parsed = urlparse(urls[0])
@@ -470,6 +481,7 @@ async def main(
         create_protocol=HttpClient,
         session_ticket_handler=save_session_ticket,
         local_port=local_port,
+        # local_host="0.0.0.0", # Removed as it caused TypeError with aioquic 1.2.0
         wait_connected=not zero_rtt,
     ) as client:
         client = cast(HttpClient, client)
@@ -488,21 +500,61 @@ async def main(
 
             await ws.close()
         else:
-            # perform request
-            coros = [
-                perform_http_request(
-                    client=client,
-                    url=url,
-                    # This data is already None if upload_file was specified
-                    # (handled in __main__)
-                    data=data,
-                    include=include,
-                    output_dir=output_dir,
-                    upload_file_path=upload_file,
-                )
-                for url in urls
-            ]
-            await asyncio.gather(*coros)
+            # When using --num-streams, the client will attempt to create
+            # multiple streams for each specified URL.
+            # Note that the actual number of concurrent streams is limited
+            # by the server. The aioquic library will queue stream initiation
+            # attempts if the server's limit is reached, and these will be
+            # processed as the server increases its limits via MAX_STREAMS frames.
+
+            # The `data` and `upload_file` parameters for main() are derived from
+            # args.data and args.upload_file in the `if __name__ == "__main__":` block.
+            # If args.upload_file is set, data (data_to_pass) is None.
+            # This means `upload_file` takes precedence if provided.
+
+            all_coros = []
+            for url_str in urls:  # Iterate through each URL provided
+                # For each URL, create num_streams requests
+                for _ in range(num_streams):
+                    all_coros.append(
+                        perform_http_request(
+                            client=client,
+                            url=url_str,
+                            data=data,  # This is data_to_pass from __main__
+                            include=include,
+                            output_dir=output_dir,
+                            # This is args.upload_file from __main__
+                            upload_file_path=upload_file,
+                        )
+                    )
+
+            if all_coros:
+                results = await asyncio.gather(*all_coros, return_exceptions=True)
+                for i, result in enumerate(results):
+                    if isinstance(result, Exception):
+                        # Determine which URL and request number this was for context
+                        # num_streams is available in main's scope
+                        # urls is available in main's scope
+                        # Avoid division by zero if num_streams somehow is 0
+                        url_idx = i // num_streams if num_streams > 0 else i
+                        req_num_for_url = (
+                            (i % num_streams) + 1 if num_streams > 0 else 1
+                        )
+
+                        failed_url = "unknown_url"
+                        if url_idx < len(urls):
+                            failed_url = urls[url_idx]
+
+                        logger.error(
+                            (
+                                f"Request {req_num_for_url} for URL {failed_url} "
+                                f"encountered an error: {result}"
+                            ),
+                            # Log traceback if it's an actual exception object
+                            exc_info=(
+                                result if isinstance(result, BaseException) else None
+                            ),
+                        )
 
             # process http pushes
             process_http_pushes(client=client, include=include, output_dir=output_dir)
@@ -624,6 +676,12 @@ if __name__ == "__main__":
     parser.add_argument(
         "--zero-rtt", action="store_true", help="try to send requests using 0-RTT"
     )
+    parser.add_argument(
+        "--num-streams",
+        type=int,
+        default=1,
+        help="the number of streams to create (default: 1)",
+    )
 
     args = parser.parse_args()
 
@@ -694,5 +752,6 @@ if __name__ == "__main__":
             local_port=args.local_port,
             zero_rtt=args.zero_rtt,
             upload_file=args.upload_file,
+            num_streams=args.num_streams,
         )
     )

--- a/examples/http3_server.py
+++ b/examples/http3_server.py
@@ -2,6 +2,7 @@ import argparse
 import asyncio
 import importlib
 import logging
+import os
 import time
 from collections import deque
 from email.utils import formatdate
@@ -329,6 +330,42 @@ class HttpServerProtocol(QuicConnectionProtocol):
         self._http: Optional[HttpConnection] = None
 
     def http_event_received(self, event: H3Event) -> None:
+        if isinstance(event, HeadersReceived):
+            # Log raw headers for diagnostic purposes
+            logged_headers = []
+            for name, value in event.headers:
+                max_value_len = 100  # General max length for a header value
+                if isinstance(self._http, H0Connection) and name == b":path":
+                    # For H0Connection, the path can contain the body for PUT/POST
+                    # Truncate path more aggressively if it looks like binary data.
+                    # For simplicity, always truncate to a shorter length for logging.
+                    max_value_len = 100
+                    prefix = value[:max_value_len]
+                    try:
+                        # Attempt to decode a small prefix to see if it's text-like
+                        prefix.decode("utf-8")
+                        # If decodable, log its prefix (still truncated)
+                        display_value = prefix.decode("ascii", errors="replace")
+                        if len(value) > max_value_len:
+                            display_value += "..."
+                        logged_headers.append((name, display_value))
+                    except UnicodeDecodeError:
+                        # If not decodable as UTF-8, it's likely binary.
+                        logged_headers.append(
+                            (name, f"<binary data, {len(value)} bytes>")
+                        )
+                else:
+                    # For other headers or H3 connections
+                    display_value = value[:max_value_len].decode(
+                        "ascii", errors="replace"
+                    )
+                    if len(value) > max_value_len:
+                        display_value += "..."
+                    logged_headers.append((name, display_value))
+            self._quic._logger.info(
+                f"Raw headers received on stream {event.stream_id}: {logged_headers}"
+            )
+
         if isinstance(event, HeadersReceived) and event.stream_id not in self._handlers:
             authority = None
             headers = []
@@ -348,6 +385,33 @@ class HttpServerProtocol(QuicConnectionProtocol):
                     protocol = value.decode()
                 elif header and not header.startswith(b":"):
                     headers.append((header, value))
+
+            # Handle HTTP/0.9 PUT/POST attempts
+            if isinstance(self._http, H0Connection) and method in ("PUT", "POST"):
+                # Truncate raw_path before decoding to limit length of binary data
+                # representation
+                truncated_raw_path = raw_path[:100]  # Max 100 bytes
+                log_path_display = truncated_raw_path.decode("ascii", errors="replace")
+                if len(raw_path) > 100:
+                    log_path_display += "..."
+                self._quic._logger.warning(
+                    (
+                        "HTTP/0.9 %s request for path starting with '%s' on stream %d "
+                        "is not supported. Sending error and closing stream."
+                    ),
+                    method,
+                    log_path_display,
+                    event.stream_id,
+                )
+                error_body = b"Error: Method Not Allowed for HTTP/0.9 requests.\r\n"
+                self._http.send_data(
+                    stream_id=event.stream_id, data=error_body, end_stream=True
+                )
+                self.transmit()
+                # Since this code is within the "if event.stream_id not in
+                # self._handlers" block, simply returning should prevent it from
+                # being added to _handlers and processed by ASGI.
+                return
 
             if b"?" in raw_path:
                 path_bytes, query_string = raw_path.split(b"?", maxsplit=1)
@@ -567,7 +631,39 @@ if __name__ == "__main__":
     parser.add_argument(
         "-v", "--verbose", action="store_true", help="increase logging verbosity"
     )
+    parser.add_argument(
+        "--upload-dir",
+        type=str,
+        default=None,
+        help=(
+            "Directory to save uploaded files (influences AIOQUIC_UPLOAD_DIR "
+            "in demo.py)"
+        ),
+    )
+    parser.add_argument(
+        "--static-dir",
+        type=str,
+        default=None,
+        help=(
+            "Root directory for serving static files (influences STATIC_ROOT "
+            "in demo.py)"
+        ),
+    )
     args = parser.parse_args()
+
+    # Set environment variables based on command-line arguments
+    if args.upload_dir is not None:
+        abs_upload_dir = os.path.abspath(args.upload_dir)
+        os.environ["AIOQUIC_UPLOAD_DIR"] = abs_upload_dir
+        # Use logging if available and configured, otherwise print
+        # Assuming logger might not be configured yet, print for simplicity
+        # as per instructions
+        print(f"INFO: Uploads will be saved to directory: {abs_upload_dir}")
+
+    if args.static_dir is not None:
+        abs_static_dir = os.path.abspath(args.static_dir)
+        os.environ["STATIC_ROOT"] = abs_static_dir
+        print(f"INFO: Static files will be served from directory: {abs_static_dir}")
 
     logging.basicConfig(
         format="%(asctime)s %(levelname)s %(name)s %(message)s",

--- a/examples/http3_server.py
+++ b/examples/http3_server.py
@@ -25,6 +25,7 @@ from aioquic.h3.exceptions import NoAvailablePushIDError
 from aioquic.quic.configuration import QuicConfiguration
 from aioquic.quic.events import DatagramFrameReceived, ProtocolNegotiated, QuicEvent
 from aioquic.quic.logger import QuicFileLogger
+from aioquic.quic.packet import QuicProtocolVersion
 from aioquic.tls import SessionTicket
 
 try:
@@ -695,6 +696,10 @@ if __name__ == "__main__":
         max_datagram_size=args.max_datagram_size,
         quic_logger=quic_logger,
         secrets_log_file=secrets_log_file,
+        supported_versions=[
+            QuicProtocolVersion.VERSION_2,
+            QuicProtocolVersion.VERSION_1,
+        ],
     )
 
     # load SSL certificate and key


### PR DESCRIPTION
Server side
```
/tests/ssl_key.pem -v --retry --help
usage: http3_server.py [-h] -c CERTIFICATE [--congestion-control-algorithm CONGESTION_CONTROL_ALGORITHM] [--host HOST] [--port PORT]
                       [-k PRIVATE_KEY] [-l SECRETS_LOG] [--max-datagram-size MAX_DATAGRAM_SIZE] [-q QUIC_LOG] [--retry] [-v]
                       [--upload-dir UPLOAD_DIR] [--static-dir STATIC_DIR]
                       [app]

QUIC server

positional arguments:
  app                   the ASGI application as <module>:<attribute>

options:
  -h, --help            show this help message and exit
  -c CERTIFICATE, --certificate CERTIFICATE
                        load the TLS certificate from the specified file
  --congestion-control-algorithm CONGESTION_CONTROL_ALGORITHM
                        use the specified congestion control algorithm
  --host HOST           listen on the specified address (defaults to ::)
  --port PORT           listen on the specified port (defaults to 4433)
  -k PRIVATE_KEY, --private-key PRIVATE_KEY
                        load the TLS private key from the specified file
  -l SECRETS_LOG, --secrets-log SECRETS_LOG
                        log secrets to a file, for use with Wireshark
  --max-datagram-size MAX_DATAGRAM_SIZE
                        maximum datagram size to send, excluding UDP or IP overhead
  -q QUIC_LOG, --quic-log QUIC_LOG
                        log QUIC events to QLOG files in the specified directory
  --retry               send a retry for new connections
  -v, --verbose         increase logging verbosity
  --upload-dir UPLOAD_DIR
                        Directory to save uploaded files (influences AIOQUIC_UPLOAD_DIR in demo.py)
  --static-dir STATIC_DIR
                        Root directory for serving static files (influences STATIC_ROOT in demo.py)
root@ubuntu:~#
```
Client side
```
root@ubuntu:~# python3 /root/aioquic/examples/http3_client.py --ca-certs /root/aioquic/tests/pycacert.pem -v --insecure https://172.16.2.2:4433//tmp/BPS.pdf --upload-file /var/www/html/BPS.pdf --num-streams 2 --help
usage: http3_client.py [-h] [--ca-certs CA_CERTS] [--certificate CERTIFICATE] [--cipher-suites CIPHER_SUITES]
                       [--congestion-control-algorithm CONGESTION_CONTROL_ALGORITHM] [-d DATA] [--upload-file UPLOAD_FILE] [-i]
                       [--insecure] [--legacy-http] [--max-data MAX_DATA] [--max-stream-data MAX_STREAM_DATA] [--negotiate-v2]
                       [--output-dir OUTPUT_DIR] [--private-key PRIVATE_KEY] [-q QUIC_LOG] [-l SECRETS_LOG] [-s SESSION_TICKET] [-v]
                       [--local-port LOCAL_PORT] [--max-datagram-size MAX_DATAGRAM_SIZE] [--zero-rtt] [--local-ip LOCAL_IP]
                       [--num-streams NUM_STREAMS]
                       url [url ...]

HTTP/3 client

positional arguments:
  url                   the URL to query (must be HTTPS)

options:
  -h, --help            show this help message and exit
  --ca-certs CA_CERTS   load CA certificates from the specified file
  --certificate CERTIFICATE
                        load the TLS certificate from the specified file
  --cipher-suites CIPHER_SUITES
                        only advertise the given cipher suites, e.g. `AES_256_GCM_SHA384,CHACHA20_POLY1305_SHA256`
  --congestion-control-algorithm CONGESTION_CONTROL_ALGORITHM
                        use the specified congestion control algorithm
  -d DATA, --data DATA  send the specified data in a POST request
  --upload-file UPLOAD_FILE
                        path to the file to upload (disables --data if used)
  -i, --include         include the HTTP response headers in the output
  --insecure            do not validate server certificate
  --legacy-http         use HTTP/0.9
  --max-data MAX_DATA   connection-wide flow control limit (default: 1048576)
  --max-stream-data MAX_STREAM_DATA
                        per-stream flow control limit (default: 1048576)
  --negotiate-v2        start with QUIC v1 and try to negotiate QUIC v2
  --output-dir OUTPUT_DIR
                        write downloaded files to this directory
  --private-key PRIVATE_KEY
                        load the TLS private key from the specified file
  -q QUIC_LOG, --quic-log QUIC_LOG
                        log QUIC events to QLOG files in the specified directory
  -l SECRETS_LOG, --secrets-log SECRETS_LOG
                        log secrets to a file, for use with Wireshark
  -s SESSION_TICKET, --session-ticket SESSION_TICKET
                        read and write session ticket from the specified file
  -v, --verbose         increase logging verbosity
  --local-port LOCAL_PORT
                        local port to bind for connections
  --max-datagram-size MAX_DATAGRAM_SIZE
                        maximum datagram size to send, excluding UDP or IP overhead
  --zero-rtt            try to send requests using 0-RTT
  --local-ip LOCAL_IP   local IP address to bind for connections
  --num-streams NUM_STREAMS
                        the number of streams to create (default: 1)
root@ubuntu:~#
```