### PR TITLE
http3: Fix stream memory leak in the H3Connection

### DIFF
--- a/tests/test_h3.py
+++ b/tests/test_h3.py
@@ -1711,6 +1711,121 @@ class H3ConnectionTest(TestCase):
             ),
         )
 
+    def test_streams_are_closed_after_requests(self):
+        with h3_client_and_server() as (quic_client, quic_server):
+            h3_client = H3Connection(quic_client)
+            h3_server = H3Connection(quic_server)
+
+            for _ in range(6):
+                self._make_request(h3_client, h3_server)
+
+            # Only 3 streams should be opened: Control, QPACK encoder and QPACK decoder
+            self.assertEqual(len(h3_client._stream), 3)
+            self.assertEqual(len(h3_server._stream), 3)
+
+    def test_streams_are_not_closed_prematurely(self):
+        with h3_client_and_server() as (quic_client, quic_server):
+            h3_client = H3Connection(quic_client)
+            h3_server = H3Connection(quic_server)
+
+            # No streams opened
+            self.assertEqual(len(h3_client._stream), 0)
+            self.assertEqual(len(h3_server._stream), 0)
+
+            # Send request
+            stream_id = quic_client.get_next_available_stream_id()
+            h3_client.send_headers(
+                stream_id=stream_id,
+                headers=[
+                    (b":method", b"POST"),
+                    (b":scheme", b"https"),
+                    (b":authority", b"localhost"),
+                    (b":path", b"/"),
+                    (b"x-foo", b"client"),
+                ],
+            )
+
+            # The request stream was opened
+            self.assertEqual(len(h3_client._stream), 1)
+
+            h3_client.send_data(stream_id=stream_id, data=b"p1ng", end_stream=False)
+            # Still the same stream
+            self.assertEqual(len(h3_client._stream), 1)
+
+            h3_client.send_data(stream_id=stream_id, data=b"", end_stream=True)
+            # Still the same stream because server didn't end the stream yet
+            self.assertEqual(len(h3_client._stream), 1)
+
+            h3_transfer(h3_client._quic, h3_server)
+
+            self.assertEqual(len(h3_client._stream), 1)
+            # Server has 4 streams: Control, QPACK encoder, QPACK decoder and
+            # the request stream
+            self.assertEqual(len(h3_server._stream), 4)
+
+            h3_server.send_headers(
+                stream_id=stream_id,
+                headers=[
+                    (b":status", b"200"),
+                    (b"content-type", b"text/html; charset=utf-8"),
+                    (b"x-foo", b"server"),
+                ],
+            )
+            h3_transfer(h3_server._quic, h3_client)
+            h3_transfer(h3_client._quic, h3_server)
+
+            # Now both have 4 streams still open
+            self.assertEqual(len(h3_server._stream), 4)
+            self.assertEqual(len(h3_client._stream), 4)
+
+            h3_server.send_data(
+                stream_id=stream_id,
+                data=b"p0ng",
+                end_stream=False,
+            )
+            h3_transfer(h3_server._quic, h3_client)
+            h3_transfer(h3_client._quic, h3_server)
+
+            # All streams are still open
+            self.assertEqual(len(h3_server._stream), 4)
+            self.assertEqual(len(h3_client._stream), 4)
+
+            h3_server.send_data(
+                stream_id=stream_id,
+                data=b"",
+                end_stream=True,
+            )
+            h3_transfer(h3_server._quic, h3_client)
+            h3_transfer(h3_client._quic, h3_server)
+            # Request streams are closed. The Control and QPACK remain open to
+            # the end of connection
+            self.assertEqual(len(h3_client._stream), 3)
+            self.assertEqual(len(h3_server._stream), 3)
+
+    def test_double_sending_stream_closing(self):
+        quic_client = FakeQuicConnection(
+            configuration=QuicConfiguration(is_client=True)
+        )
+        h3_client = H3Connection(quic_client)
+
+        stream_id = quic_client.get_next_available_stream_id()
+        h3_client.send_headers(
+            stream_id=stream_id,
+            headers=[
+                (b":method", b"POST"),
+                (b":scheme", b"https"),
+                (b":authority", b"localhost"),
+                (b":path", b"/"),
+                (b"x-foo", b"client"),
+            ],
+            end_stream=True,
+        )
+
+        with self.assertRaises(FrameUnexpected) as assert_err:
+            h3_client.send_data(stream_id, b"data", end_stream=True)
+
+        self.assertEqual(str(assert_err.exception), "stream was already ended")
+
 
 class H3ParserTest(TestCase):
     def test_parse_settings_duplicate_identifier(self):


### PR DESCRIPTION
Hello! I was testing the library with Hypercorn and noticed that long-lived HTTP3 connections gradually consume server memory, so I decided to investigate.

I found that the [H3Connection._stream](https://github.com/G1gg1L3s/aioquic/blob/218f940467cf25d364890a602b8fc451ca635062/src/aioquic/h3/connection.py#L387C9-L387C21) dict is never cleared of created streams, leading to a memory leak.

This PR addresses the issue. First, I introduced tracking of whether HTTP/3 streams have ended on both sides. Then, I refactored `H3Connection._get_or_create_stream` to be a context manager which automatically removes streams if they are ended on both sides and are not blocked. Finally, I added a test for this case, though it's a bit dirty because it accesses internal H3Connection field, but it works well overall.

Let me know what you think! I may miss something in the H3 state machine, but overall I tried a couple of approaches and the current one seems to play nicely with the way HTTP3 is implemented.

#### Similar issue in QUIC

By the way, there is a small memory leak on the QUIC level, but it's rather a feature and not a bug :) I'm talking about the [QuicConnection._streams_finished](https://github.com/aiortc/aioquic/blob/e2a401a6430255812a705e82ab0d127d46416d91/src/aioquic/quic/connection.py#L373) set, which is populated with finished streams to prevent their reusage. In theory it means that long-living connections with short-living streams will also consume memory, though it's a slow process.

I've seen a similar approach in Rust [quiche](https://github.com/cloudflare/quiche/blob/762c61833f644374bb58da6d69af6426af1400d4/quiche/src/stream/mod.rs#L99), which tracks used stream IDs in a set.

However, I didn't find anything similar in [quic-go](https://github.com/quic-go/quic-go/blob/fd32cf5c69a5941890d55041313a71a2e42a7773/streams_map_incoming.go#L115) or in [quinn](https://github.com/quinn-rs/quinn/blob/64139181e0fcdf337737d32dac077e96391d9d52/quinn-proto/src/connection/streams/state.rs#L964). I haven’t tested or looked into it deeply, but I suspect that they use some mechanism to avoid storing the entire set. So, it may be worth investigating.