### PR TITLE
Limit the number of remote path challenges stored per path

### DIFF
--- a/src/aioquic/quic/connection.py
+++ b/src/aioquic/quic/connection.py
@@ -68,7 +68,7 @@ EPOCH_SHORTCUTS = {
     "1": tls.Epoch.ONE_RTT,
 }
 MAX_EARLY_DATA = 0xFFFFFFFF
-MAX_REMOTE_CHALLENGES = 5
+MAX_REMOTE_CHALLENGES = 32
 MAX_LOCAL_CHALLENGES = 5
 SECRETS_LABELS = [
     [
@@ -2042,7 +2042,11 @@ class QuicConnection:
                 self._quic_logger.encode_path_challenge_frame(data=data)
             )
 
-        context.network_path.remote_challenges.append(data)
+        # Append the new path challenge unless our limit was reached.
+        # This is technically not compliant with RFC 9000 but it's needed
+        # to avoid resource exhaustion attacks.
+        if len(context.network_path.remote_challenges) < MAX_REMOTE_CHALLENGES:
+            context.network_path.remote_challenges.append(data)
 
     def _handle_path_response_frame(
         self, context: QuicReceiveContext, frame_type: int, buf: Buffer


### PR DESCRIPTION
In order to avoid resource exhaustion, limit the number of remote path challenges we store per path.If the limit is exceeded, we drop any additional path challenge.


Fixes: #544.