### PR TITLE
Send PATH_CHALLENGE before other frame types

### DIFF
--- a/src/aioquic/quic/connection.py
+++ b/src/aioquic/quic/connection.py
@@ -3020,15 +3020,6 @@ class QuicConnection:
             builder.start_packet(packet_type, crypto)
 
             if self._handshake_complete:
-                # ACK
-                if space.ack_at is not None and space.ack_at <= now:
-                    self._write_ack_frame(builder=builder, space=space, now=now)
-
-                # HANDSHAKE_DONE
-                if self._handshake_done_pending:
-                    self._write_handshake_done_frame(builder=builder)
-                    self._handshake_done_pending = False
-
                 # PATH CHALLENGE
                 if not (network_path.is_validated or network_path.local_challenge_sent):
                     challenge = os.urandom(8)
@@ -3039,6 +3030,15 @@ class QuicConnection:
                         challenge=challenge, network_path=network_path
                     )
                     network_path.local_challenge_sent = True
+
+                # ACK
+                if space.ack_at is not None and space.ack_at <= now:
+                    self._write_ack_frame(builder=builder, space=space, now=now)
+
+                # HANDSHAKE_DONE
+                if self._handshake_done_pending:
+                    self._write_handshake_done_frame(builder=builder)
+                    self._handshake_done_pending = False
 
                 # PATH RESPONSE
                 while len(network_path.remote_challenges) > 0:

--- a/src/aioquic/quic/connection.py
+++ b/src/aioquic/quic/connection.py
@@ -3032,20 +3032,20 @@ class QuicConnection:
                 # PATH CHALLENGE
                 if not (network_path.is_validated or network_path.local_challenge_sent):
                     challenge = os.urandom(8)
-                    self._add_local_challenge(
-                        challenge=challenge, network_path=network_path
-                    )
                     self._write_path_challenge_frame(
                         builder=builder, challenge=challenge
+                    )
+                    self._add_local_challenge(
+                        challenge=challenge, network_path=network_path
                     )
                     network_path.local_challenge_sent = True
 
                 # PATH RESPONSE
                 while len(network_path.remote_challenges) > 0:
-                    challenge = network_path.remote_challenges.popleft()
                     self._write_path_response_frame(
-                        builder=builder, challenge=challenge
+                        builder=builder, challenge=network_path.remote_challenges[0]
                     )
+                    network_path.remote_challenges.popleft()
 
                 # NEW_CONNECTION_ID
                 for connection_id in self._host_cids:


### PR DESCRIPTION
When building packets, generate PATH_CHALLENGE frames first to ensure that the first packet on a path requiring  validation contains a PATH_CHALLENGE.