### PR TITLE
Silence a cibuildwheel warning

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -142,7 +142,7 @@ jobs:
           CIBW_ENVIRONMENT: AIOQUIC_SKIP_TESTS=ipv6,loss CFLAGS=-I/tmp/vendor/include LDFLAGS=-L/tmp/vendor/lib
           CIBW_ENVIRONMENT_WINDOWS: AIOQUIC_SKIP_TESTS=ipv6,loss INCLUDE=C:\\cibw\\vendor\\include LIB=C:\\cibw\\vendor\\lib
           # The limited API is not available on free-threaded builds.
-          CIBW_SKIP: 'cp3??t-* pp*'
+          CIBW_SKIP: 'cp3??t-*'
           CIBW_TEST_COMMAND: python -m unittest discover -t {project} -s {project}/tests
           # There are no binary wheels for cryptography on 32-bit platforms.
           CIBW_TEST_SKIP: "*-{manylinux_i686,musllinux_i686,win32}"


### PR DESCRIPTION
PyPy builds are no longer done by default, so we do not need to exclude them using `CIBW_SKIP`.