### PR TITLE
Add `WEBTRANSPORT_MAX_SESSIONS` to `Setting`

### DIFF
--- a/src/aioquic/h3/connection.py
+++ b/src/aioquic/h3/connection.py
@@ -89,6 +89,8 @@ class Setting(IntEnum):
     H3_DATAGRAM = 0x33
     # https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-http2-02#section-10.1
     ENABLE_WEBTRANSPORT = 0x2B603742
+    # https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-http3-07#section-8.2
+    WEBTRANSPORT_MAX_SESSIONS = 0xC671706A
 
     # Dummy setting to check it is correctly ignored by the peer.
     # https://datatracker.ietf.org/doc/html/rfc9114#section-7.2.4.1
@@ -677,6 +679,7 @@ class H3Connection:
         if self._enable_webtransport:
             settings[Setting.H3_DATAGRAM] = 1
             settings[Setting.ENABLE_WEBTRANSPORT] = 1
+            settings[Setting.WEBTRANSPORT_MAX_SESSIONS] = 256
         return settings
 
     def _handle_control_frame(self, frame_type: int, frame_data: bytes) -> None:


### PR DESCRIPTION
Safari 26.4 (21624.1.16.11.4) (or the Network.framework shipped with macOS 26.4.1) appears to require the `WEBTRANSPORT_MAX_SESSIONS` setting in [draft-ietf-webtrans-http3-07](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-http3-07#section-8.2) to work.

Note that its predecessors and successors are not added for now because they do not block any released browser and are still in draft status.